### PR TITLE
feat(math-flight): 운석 크기/판정 개선 + 전체 게임 max-width 적용

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,6 +67,7 @@ BrainTouch/
 │   │   └── PhaserGame.tsx          # Phaser 래퍼 컴포넌트
 │   ├── shared/                     # 공통 모듈
 │   │   ├── colors.ts               # 공통 색상 팔레트
+│   │   ├── constants.ts            # 공통 상수 (GAME_LAYOUT 등)
 │   │   └── ui.ts                   # 공통 UI 유틸리티 (버튼, 배경, 카운트다운)
 │   └── games/
 │       ├── brain-touch/            # Brain Touch 게임
@@ -284,6 +285,8 @@ refactor/<game-name>-<description>
 
 | 날짜       | 작업 내용                                              |
 | ---------- | ------------------------------------------------------ |
+| 2025-12-22 | 전체 게임 최대 너비 제한 (480px) + 공통 상수 분리       |
+| 2025-12-22 | Math Flight 운석 크기 레인 비율 적용 + 판정 방식 개선  |
 | 2025-12-19 | Number Balloon (숫자풍선) MVP 구현                     |
 | 2025-12-19 | Block Sum (블록셈) MVP 구현                            |
 | 2025-12-19 | 공통 모듈 분리 (src/shared/colors.ts, ui.ts)           |
@@ -301,4 +304,4 @@ refactor/<game-name>-<description>
 
 ---
 
-_마지막 업데이트: 2025-12-19_
+_마지막 업데이트: 2025-12-22_

--- a/src/games/block-sum/config.ts
+++ b/src/games/block-sum/config.ts
@@ -1,6 +1,7 @@
 import Phaser from 'phaser';
 import { GameScene } from './scenes/GameScene';
 import { ResultScene } from './scenes/ResultScene';
+import { GAME_LAYOUT } from '../../shared/constants';
 
 export interface GameResult {
   score: number; // 총 점수
@@ -17,8 +18,8 @@ export function getGameConfig(
     parent,
     backgroundColor: '#1a1a2e',
     scale: {
-      mode: Phaser.Scale.RESIZE,
-      width: parent.clientWidth,
+      mode: Phaser.Scale.FIT,
+      width: Math.min(parent.clientWidth, GAME_LAYOUT.MAX_WIDTH),
       height: parent.clientHeight,
       autoCenter: Phaser.Scale.CENTER_BOTH,
     },

--- a/src/games/brain-touch/config.ts
+++ b/src/games/brain-touch/config.ts
@@ -1,5 +1,6 @@
 import Phaser from 'phaser';
 import { MainScene } from './scenes/MainScene';
+import { GAME_LAYOUT } from '../../shared/constants';
 
 export function getGameConfig(
   parent: HTMLElement,
@@ -10,8 +11,8 @@ export function getGameConfig(
     parent,
     backgroundColor: '#1a1a2e',
     scale: {
-      mode: Phaser.Scale.RESIZE,
-      width: parent.clientWidth,
+      mode: Phaser.Scale.FIT,
+      width: Math.min(parent.clientWidth, GAME_LAYOUT.MAX_WIDTH),
       height: parent.clientHeight,
       autoCenter: Phaser.Scale.CENTER_BOTH,
     },

--- a/src/games/math-flight/config.ts
+++ b/src/games/math-flight/config.ts
@@ -1,6 +1,7 @@
 import Phaser from 'phaser';
 import { GameScene } from './scenes/GameScene';
 import { ResultScene } from './scenes/ResultScene';
+import { GAME_LAYOUT } from '../../shared/constants';
 
 export interface GameResult {
   totalScore: number;
@@ -17,8 +18,8 @@ export function getGameConfig(
     parent,
     backgroundColor: '#0a0a1a',
     scale: {
-      mode: Phaser.Scale.RESIZE,
-      width: parent.clientWidth,
+      mode: Phaser.Scale.FIT,
+      width: Math.min(parent.clientWidth, GAME_LAYOUT.MAX_WIDTH),
       height: parent.clientHeight,
       autoCenter: Phaser.Scale.CENTER_BOTH,
     },

--- a/src/games/math-flight/scenes/GameScene.ts
+++ b/src/games/math-flight/scenes/GameScene.ts
@@ -26,11 +26,15 @@ const COLORS = {
 // 레인 X 좌표 비율
 const LANE_POSITIONS = [0.1, 0.3, 0.5, 0.7, 0.9];
 
+// 운석 크기 margin (레인 너비 대비)
+const METEOR_MARGIN = 0.15; // 15% margin 양쪽
+
 // 운석 스프라이트
 interface MeteorSprite {
   data: MeteorData;
   container: Phaser.GameObjects.Container;
   y: number;
+  processed: boolean; // 판정 완료 여부
 }
 
 export class GameScene extends Phaser.Scene {
@@ -56,8 +60,11 @@ export class GameScene extends Phaser.Scene {
 
   // 레이아웃
   private laneXPositions: number[] = [];
+  private laneWidth = 0; // 레인 너비
+  private meteorRadius = 0; // 운석 반지름
   private playerY = 0;
   private meteorStartY = 0;
+  private collisionLineY = 0; // 판정 라인 Y 좌표
 
   constructor() {
     super({ key: 'GameScene' });
@@ -96,8 +103,16 @@ export class GameScene extends Phaser.Scene {
 
   private calculateLayout(width: number, height: number): void {
     this.laneXPositions = LANE_POSITIONS.map((ratio) => width * ratio);
+
+    // 레인 너비 계산 (인접 레인 간 거리)
+    this.laneWidth = width * (LANE_POSITIONS[1] - LANE_POSITIONS[0]);
+
+    // 운석 반지름: 레인 너비의 절반에서 margin 제외
+    this.meteorRadius = (this.laneWidth / 2) * (1 - METEOR_MARGIN);
+
     this.playerY = height * 0.85;
-    this.meteorStartY = -50;
+    this.collisionLineY = this.playerY; // 판정 라인 = 플레이어 Y
+    this.meteorStartY = -this.meteorRadius - 10;
     this.baseSpeed = height / 3000; // 3초에 화면 통과 (기본)
   }
 
@@ -285,18 +300,20 @@ export class GameScene extends Phaser.Scene {
 
     const container = this.add.container(x, y);
 
-    // 운석 배경 (모두 동일 색상)
-    const bg = this.add.circle(0, 0, 30, COLORS.METEOR_NORMAL);
+    // 운석 배경 (레인 너비에 맞춘 크기)
+    const bg = this.add.circle(0, 0, this.meteorRadius, COLORS.METEOR_NORMAL);
 
-    // 숫자 텍스트
+    // 숫자 텍스트 (운석 크기에 비례, 고해상도)
+    const fontSize = Math.max(16, Math.floor(this.meteorRadius * 0.7));
     const text = this.add
       .text(0, 0, data.value.toString(), {
-        fontSize: '20px',
+        fontSize: `${fontSize}px`,
         fontFamily: 'Pretendard, sans-serif',
         color: '#ffffff',
         fontStyle: 'bold',
       })
-      .setOrigin(0.5);
+      .setOrigin(0.5)
+      .setResolution(2); // 고해상도 렌더링으로 블러 방지
 
     container.add([bg, text]);
 
@@ -304,6 +321,7 @@ export class GameScene extends Phaser.Scene {
       data,
       container,
       y,
+      processed: false, // 아직 판정 안됨
     };
   }
 
@@ -327,7 +345,8 @@ export class GameScene extends Phaser.Scene {
 
     this.meteors.forEach((meteor) => {
       meteor.y += currentSpeed * delta;
-      meteor.container.y = meteor.y;
+      // 정수 좌표로 렌더링하여 블러 방지
+      meteor.container.y = Math.round(meteor.y);
 
       // 화면 밖으로 나간 운석 제거
       if (meteor.y > height + 50) {
@@ -342,24 +361,56 @@ export class GameScene extends Phaser.Scene {
   private checkCollisions(): void {
     if (this.hasCollidedThisWave) return;
 
-    const collisionRadius = 35;
+    // 판정 허용 범위 (Y 좌표 기준)
+    const collisionThreshold = 20;
+
+    // 플레이어가 현재 어느 레인에 있는지 판정
+    const playerLane = this.getPlayerLane();
 
     for (let i = this.meteors.length - 1; i >= 0; i--) {
       const meteor = this.meteors[i];
-      const meteorX = this.laneXPositions[meteor.data.lane];
 
-      const dx = this.playerX - meteorX;
-      const dy = this.playerY - meteor.y;
-      const distance = Math.sqrt(dx * dx + dy * dy);
+      // 이미 판정된 운석은 스킵
+      if (meteor.processed) continue;
 
-      if (distance < collisionRadius) {
-        this.hasCollidedThisWave = true;
-        this.handleCollision(meteor);
-        meteor.container.destroy();
-        this.meteors.splice(i, 1);
-        break;
+      // 운석이 판정 라인을 지나갔는지 체크
+      const crossedLine =
+        meteor.y >= this.collisionLineY - collisionThreshold &&
+        meteor.y <= this.collisionLineY + collisionThreshold;
+
+      if (crossedLine) {
+        // 이 운석의 레인과 플레이어 레인이 같으면 충돌!
+        if (meteor.data.lane === playerLane) {
+          this.hasCollidedThisWave = true;
+          meteor.processed = true;
+          this.handleCollision(meteor);
+          meteor.container.destroy();
+          this.meteors.splice(i, 1);
+          break;
+        }
+      }
+
+      // 운석이 판정 라인을 완전히 지나갔으면 처리 완료로 표시
+      if (meteor.y > this.collisionLineY + collisionThreshold) {
+        meteor.processed = true;
       }
     }
+  }
+
+  // 플레이어가 현재 어느 레인에 있는지 판정
+  private getPlayerLane(): number {
+    let closestLane = 0;
+    let minDistance = Infinity;
+
+    for (let i = 0; i < this.laneXPositions.length; i++) {
+      const distance = Math.abs(this.playerX - this.laneXPositions[i]);
+      if (distance < minDistance) {
+        minDistance = distance;
+        closestLane = i;
+      }
+    }
+
+    return closestLane;
   }
 
   private handleCollision(meteor: MeteorSprite): void {

--- a/src/games/number-balloon/config.ts
+++ b/src/games/number-balloon/config.ts
@@ -1,6 +1,7 @@
 import Phaser from 'phaser';
 import { GameScene } from './scenes/GameScene';
 import { ResultScene } from './scenes/ResultScene';
+import { GAME_LAYOUT } from '../../shared/constants';
 
 export interface GameResult {
   score: number; // 총 점수
@@ -17,8 +18,8 @@ export function getGameConfig(
     parent,
     backgroundColor: '#87CEEB', // 하늘색 배경
     scale: {
-      mode: Phaser.Scale.RESIZE,
-      width: parent.clientWidth,
+      mode: Phaser.Scale.FIT,
+      width: Math.min(parent.clientWidth, GAME_LAYOUT.MAX_WIDTH),
       height: parent.clientHeight,
       autoCenter: Phaser.Scale.CENTER_BOTH,
     },

--- a/src/games/speed-math/config.ts
+++ b/src/games/speed-math/config.ts
@@ -3,6 +3,7 @@ import { ModeSelectScene } from './scenes/ModeSelectScene';
 import { GameScene } from './scenes/GameScene';
 import { GameSceneHW } from './scenes/GameSceneHW';
 import { ResultScene } from './scenes/ResultScene';
+import { GAME_LAYOUT } from '../../shared/constants';
 
 export interface GameResult {
   totalTime: number; // 총 소요 시간 (ms)
@@ -17,8 +18,8 @@ export function getGameConfig(
     parent,
     backgroundColor: '#1a1a2e',
     scale: {
-      mode: Phaser.Scale.RESIZE,
-      width: parent.clientWidth,
+      mode: Phaser.Scale.FIT,
+      width: Math.min(parent.clientWidth, GAME_LAYOUT.MAX_WIDTH),
       height: parent.clientHeight,
       autoCenter: Phaser.Scale.CENTER_BOTH,
     },

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -1,0 +1,10 @@
+/**
+ * 브레인터치 공통 상수
+ */
+
+// 게임 화면 설정
+export const GAME_LAYOUT = {
+  /** 게임 화면 최대 너비 (모바일 기준) */
+  MAX_WIDTH: 480,
+} as const;
+


### PR DESCRIPTION
## 📋 변경 사항

### Math Flight 게임 개선
- **운석 크기**: 고정 크기(30px) → 레인 너비에 비례하도록 변경 (15% margin)
- **충돌 판정**: 거리 기반 → Y좌표 라인 + 레인 기반 판정으로 개선
  - 운석이 판정 라인(플레이어 Y좌표)을 지나는 순간, 플레이어가 어느 레인에 있는지로 판정
- **블러 방지**: 텍스트 해상도 2배 + 좌표 정수화

### 전체 게임 max-width 적용
- `src/shared/constants.ts` 추가 (`GAME_LAYOUT.MAX_WIDTH: 480px`)
- 모든 게임 config에 최대 너비 제한 적용 (Scale 모드: FIT)
  - brain-touch
  - speed-math
  - math-flight
  - block-sum
  - number-balloon

## 🔧 변경된 파일
- `src/shared/constants.ts` (신규)
- `src/games/*/config.ts` (5개 게임)
- `src/games/math-flight/scenes/GameScene.ts`
- `CLAUDE.md`