### PR TITLE
feat(brain-touch): 숫자 터치 시스템 및 하트 시스템 추가

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,10 +70,11 @@ BrainTouch/
 │   │   ├── constants.ts            # 공통 상수 (GAME_LAYOUT 등)
 │   │   └── ui.ts                   # 공통 UI 유틸리티 (버튼, 배경, 카운트다운)
 │   └── games/
-│       ├── brain-touch/            # Brain Touch 게임
+│       ├── brain-touch/            # Brain Touch 게임 (숫자 터치)
 │       │   ├── config.ts           # Phaser 설정
 │       │   └── scenes/
-│       │       └── MainScene.ts    # 메인 게임 씬
+│       │       ├── MainScene.ts    # 메인 게임 씬
+│       │       └── ResultScene.ts  # 결과 화면
 │       ├── speed-math/             # Speed Math 게임 (사칙연산)
 │       │   ├── DESIGN.md           # 게임 설계 문서
 │       │   ├── config.ts           # Phaser 설정
@@ -137,9 +138,12 @@ BrainTouch/
 
 ### `src/games/brain-touch/`
 
-- Brain Touch 게임 코드
-- `config.ts`: Phaser 설정 생성 함수
-- `scenes/MainScene.ts`: 게임 로직 (터치 게임)
+- Brain Touch 게임 (몸풀기 - 숫자 터치 게임)
+- `config.ts`: Phaser 게임 설정
+- `scenes/MainScene.ts`: 메인 게임 씬 (숫자 원, 하트 시스템, 확장 hitArea)
+- `scenes/ResultScene.ts`: 결과 화면
+- **규칙**: 원에 표시된 숫자만큼 터치해서 원 제거, 빈 곳 터치 시 하트 감소
+- **시스템**: 하트 3개, 30초 제한시간, 터치 횟수에 따른 점수 보너스
 
 ### `src/games/speed-math/`
 
@@ -285,6 +289,7 @@ refactor/<game-name>-<description>
 
 | 날짜       | 작업 내용                                              |
 | ---------- | ------------------------------------------------------ |
+| 2025-12-28 | Brain Touch 개선 (숫자 터치, 하트 시스템, ResultScene) |
 | 2025-12-22 | 전체 게임 최대 너비 제한 (480px) + 공통 상수 분리       |
 | 2025-12-22 | Math Flight 운석 크기 레인 비율 적용 + 판정 방식 개선  |
 | 2025-12-19 | Number Balloon (숫자풍선) MVP 구현                     |
@@ -304,4 +309,4 @@ refactor/<game-name>-<description>
 
 ---
 
-_마지막 업데이트: 2025-12-22_
+_마지막 업데이트: 2025-12-28_

--- a/src/games/brain-touch/config.ts
+++ b/src/games/brain-touch/config.ts
@@ -1,5 +1,6 @@
 import Phaser from 'phaser';
 import { MainScene } from './scenes/MainScene';
+import { ResultScene } from './scenes/ResultScene';
 import { GAME_LAYOUT } from '../../shared/constants';
 
 export function getGameConfig(
@@ -16,7 +17,7 @@ export function getGameConfig(
       height: parent.clientHeight,
       autoCenter: Phaser.Scale.CENTER_BOTH,
     },
-    scene: [MainScene],
+    scene: [MainScene, ResultScene],
     physics: {
       default: 'arcade',
       arcade: {

--- a/src/games/brain-touch/scenes/MainScene.ts
+++ b/src/games/brain-touch/scenes/MainScene.ts
@@ -1,13 +1,37 @@
 import Phaser from 'phaser';
+import { BASE_COLORS, THEME_PRESETS } from '../../../shared/colors';
+import { createGradientBackground, playCountdown } from '../../../shared/ui';
+
+const THEME = THEME_PRESETS.brainTouch;
+
+interface TargetCircle {
+  container: Phaser.GameObjects.Container;
+  circle: Phaser.GameObjects.Arc;
+  text: Phaser.GameObjects.Text;
+  requiredTaps: number;
+  currentTaps: number;
+  hitArea: Phaser.Geom.Circle;
+}
 
 export class MainScene extends Phaser.Scene {
+  // 게임 상태
   private score = 0;
-  private scoreText!: Phaser.GameObjects.Text;
-  private timerText!: Phaser.GameObjects.Text;
-  private targetCircle!: Phaser.GameObjects.Arc;
+  private lives = 3;
   private timeLeft = 30;
   private isPlaying = false;
   private timerEvent?: Phaser.Time.TimerEvent;
+
+  // 타겟 원
+  private target: TargetCircle | null = null;
+  private fadingHitArea: Phaser.Geom.Circle | null = null; // 사라지는 중인 원의 영역
+  private readonly BASE_RADIUS = 45;
+  private readonly HIT_AREA_MULTIPLIER = 1.4; // 터치 허용 범위 확장
+
+  // UI 요소
+  private scoreText!: Phaser.GameObjects.Text;
+  private timerText!: Phaser.GameObjects.Text;
+  private heartsContainer!: Phaser.GameObjects.Container;
+  private heartTexts: Phaser.GameObjects.Text[] = [];
 
   constructor() {
     super({ key: 'MainScene' });
@@ -16,77 +40,136 @@ export class MainScene extends Phaser.Scene {
   create(): void {
     const { width, height } = this.scale;
 
-    // 배경 그라데이션 효과
-    const bg = this.add.graphics();
-    bg.fillGradientStyle(0x1a1a2e, 0x1a1a2e, 0x16213e, 0x16213e);
-    bg.fillRect(0, 0, width, height);
+    // 배경
+    createGradientBackground(this, width, height);
 
-    // 시작 안내
-    const startText = this.add
-      .text(width / 2, height / 2, '터치하여 시작', {
-        fontSize: '28px',
-        fontFamily: 'Pretendard, sans-serif',
-        color: '#ffffff',
-      })
-      .setOrigin(0.5);
+    // UI 초기화
+    this.createUI();
 
-    // 점수 텍스트
-    this.scoreText = this.add.text(20, 20, '점수: 0', {
-      fontSize: '20px',
-      fontFamily: 'Pretendard, sans-serif',
-      color: '#e94560',
-    });
-
-    // 타이머 텍스트
-    this.timerText = this.add
-      .text(width - 20, 20, `${this.timeLeft}초`, {
-        fontSize: '20px',
-        fontFamily: 'Pretendard, sans-serif',
-        color: '#4ecca3',
-      })
-      .setOrigin(1, 0);
-
-    // 타겟 원 (초기에는 숨김)
-    this.targetCircle = this.add.circle(width / 2, height / 2, 40, 0xe94560);
-    this.targetCircle.setVisible(false);
-    this.targetCircle.setInteractive();
-
-    // 타겟 터치 시 점수 획득
-    this.targetCircle.on('pointerdown', () => {
-      if (!this.isPlaying) return;
-
-      this.score += 10;
-      this.scoreText.setText(`점수: ${this.score}`);
-
-      // 터치 효과
-      this.tweens.add({
-        targets: this.targetCircle,
-        scale: 1.3,
-        duration: 50,
-        yoyo: true,
-      });
-
-      // 새 위치로 이동
-      this.moveTarget();
-    });
-
-    // 게임 시작 터치
-    this.input.once('pointerdown', () => {
-      startText.destroy();
-      this.startGame();
-    });
+    // 시작 화면
+    this.showStartScreen();
 
     // 리사이즈 대응
     this.scale.on('resize', this.handleResize, this);
   }
 
+  private createUI(): void {
+    const { width } = this.scale;
+
+    // 점수 텍스트
+    this.scoreText = this.add
+      .text(20, 20, '점수: 0', {
+        fontSize: '22px',
+        fontFamily: 'Pretendard, sans-serif',
+        color: THEME.accentText,
+        fontStyle: 'bold',
+      })
+      .setDepth(100);
+
+    // 타이머 텍스트
+    this.timerText = this.add
+      .text(width - 20, 20, `${this.timeLeft}초`, {
+        fontSize: '22px',
+        fontFamily: 'Pretendard, sans-serif',
+        color: '#4ecca3',
+        fontStyle: 'bold',
+      })
+      .setOrigin(1, 0)
+      .setDepth(100);
+
+    // 하트(라이프) 컨테이너
+    this.heartsContainer = this.add.container(width / 2, 25).setDepth(100);
+    this.updateHeartsDisplay();
+  }
+
+  private updateHeartsDisplay(): void {
+    // 기존 하트 제거
+    this.heartTexts.forEach((h) => h.destroy());
+    this.heartTexts = [];
+
+    const heartSize = 28;
+    const spacing = 8;
+    const totalWidth = this.lives * heartSize + (this.lives - 1) * spacing;
+    const startX = -totalWidth / 2 + heartSize / 2;
+
+    for (let i = 0; i < 3; i++) {
+      const heart = this.add
+        .text(startX + i * (heartSize + spacing), 0, i < this.lives ? '❤️' : '🖤', {
+          fontSize: '24px',
+        })
+        .setOrigin(0.5);
+
+      this.heartsContainer.add(heart);
+      this.heartTexts.push(heart);
+    }
+  }
+
+  private showStartScreen(): void {
+    const { width, height } = this.scale;
+
+    // 게임 설명
+    const instructionText = this.add
+      .text(width / 2, height / 2 - 60, '🎯 숫자만큼 터치하세요!', {
+        fontSize: '24px',
+        fontFamily: 'Pretendard, sans-serif',
+        color: BASE_COLORS.TEXT_PRIMARY,
+        fontStyle: 'bold',
+      })
+      .setOrigin(0.5);
+
+    const subText = this.add
+      .text(width / 2, height / 2, '빈 곳을 터치하면 하트가 줄어요', {
+        fontSize: '16px',
+        fontFamily: 'Pretendard, sans-serif',
+        color: BASE_COLORS.TEXT_SECONDARY,
+      })
+      .setOrigin(0.5);
+
+    const startText = this.add
+      .text(width / 2, height / 2 + 80, '👆 터치하여 시작', {
+        fontSize: '20px',
+        fontFamily: 'Pretendard, sans-serif',
+        color: '#4ecca3',
+        fontStyle: 'bold',
+      })
+      .setOrigin(0.5);
+
+    // 깜빡임 효과
+    this.tweens.add({
+      targets: startText,
+      alpha: 0.5,
+      duration: 600,
+      yoyo: true,
+      repeat: -1,
+    });
+
+    // 터치하여 시작
+    this.input.once('pointerdown', () => {
+      instructionText.destroy();
+      subText.destroy();
+      startText.destroy();
+
+      // 카운트다운 후 게임 시작
+      playCountdown(this, () => {
+        this.startGame();
+      });
+    });
+  }
+
   private startGame(): void {
     this.isPlaying = true;
     this.score = 0;
+    this.lives = 3;
     this.timeLeft = 30;
+
     this.scoreText.setText('점수: 0');
-    this.targetCircle.setVisible(true);
-    this.moveTarget();
+    this.updateHeartsDisplay();
+
+    // 첫 번째 타겟 생성
+    this.spawnTarget();
+
+    // 전체 화면 터치 이벤트 (타겟 밖 터치 감지)
+    this.input.on('pointerdown', this.handleGlobalTouch, this);
 
     // 타이머 시작
     this.timerEvent = this.time.addEvent({
@@ -97,9 +180,182 @@ export class MainScene extends Phaser.Scene {
     });
   }
 
+  private handleGlobalTouch(pointer: Phaser.Input.Pointer): void {
+    if (!this.isPlaying) return;
+
+    const { x, y } = pointer;
+
+    // 현재 활성화된 타겟이 있는 경우
+    if (this.target) {
+      const circle = this.target.hitArea;
+      const distance = Phaser.Math.Distance.Between(x, y, circle.x, circle.y);
+      const isInsideHitArea = distance <= circle.radius;
+
+      if (isInsideHitArea) {
+        // 타겟 터치 성공
+        this.handleTargetTap();
+      } else {
+        // 빈 곳 터치 - 하트 감소
+        this.loseLife();
+      }
+      return;
+    }
+
+    // 원이 사라지는 중인 경우 (fadingHitArea가 있음)
+    // 어디를 터치하든 추가 터치 = 실패 (숫자보다 더 많이 터치한 것)
+    if (this.fadingHitArea) {
+      this.loseLife();
+      return;
+    }
+  }
+
+  private handleTargetTap(): void {
+    if (!this.target) return;
+
+    this.target.currentTaps++;
+
+    // 남은 터치 횟수 계산
+    const remaining = this.target.requiredTaps - this.target.currentTaps;
+
+    if (remaining <= 0) {
+      // 원 완료 - 점수 획득
+      const bonusMultiplier = this.target.requiredTaps; // 큰 숫자일수록 보너스
+      this.score += 10 * bonusMultiplier;
+      this.scoreText.setText(`점수: ${this.score}`);
+
+      // 사라지는 원의 hitArea 저장 (빈 곳 터치 판정용)
+      this.fadingHitArea = this.target.hitArea;
+
+      // 컨테이너 참조를 로컬에 저장하고, 즉시 target을 null로 설정
+      // (추가 터치 방지)
+      const containerToRemove = this.target.container;
+      this.target = null;
+
+      // 원 사라지는 효과
+      this.tweens.add({
+        targets: containerToRemove,
+        scale: 0,
+        alpha: 0,
+        duration: 150,
+        ease: 'Back.easeIn',
+        onComplete: () => {
+          containerToRemove.destroy();
+          this.fadingHitArea = null; // 사라지는 애니메이션 완료
+          this.spawnTarget();
+        },
+      });
+    } else {
+      // 아직 터치가 남았을 때만 숫자 업데이트 및 효과
+      this.target.text.setText(remaining.toString());
+
+      // 터치 효과 - 원이 잠깐 작아졌다가 커지는 효과
+      this.tweens.add({
+        targets: this.target.container,
+        scale: 0.85,
+        duration: 50,
+        yoyo: true,
+        ease: 'Quad.easeOut',
+      });
+    }
+  }
+
+  private loseLife(): void {
+    this.lives--;
+    this.updateHeartsDisplay();
+
+    // 화면 흔들림 효과
+    this.cameras.main.shake(100, 0.01);
+
+    // 화면 빨간색 플래시
+    const flash = this.add
+      .rectangle(0, 0, this.scale.width, this.scale.height, 0xff0000, 0.3)
+      .setOrigin(0)
+      .setDepth(50);
+
+    this.tweens.add({
+      targets: flash,
+      alpha: 0,
+      duration: 200,
+      onComplete: () => flash.destroy(),
+    });
+
+    if (this.lives <= 0) {
+      this.endGame();
+    }
+  }
+
+  private spawnTarget(): void {
+    if (!this.isPlaying) return;
+
+    const { width, height } = this.scale;
+    const padding = 80;
+
+    // 랜덤 위치
+    const x = Phaser.Math.Between(padding, width - padding);
+    const y = Phaser.Math.Between(120, height - padding);
+
+    // 필요한 터치 횟수 (1~5)
+    const requiredTaps = Phaser.Math.Between(1, 5);
+
+    // 원 크기 - 터치 횟수가 많을수록 조금 더 크게
+    const scale = 0.8 + requiredTaps * 0.1;
+    const radius = this.BASE_RADIUS * scale;
+
+    // 랜덤 색상
+    const colorIndex = Phaser.Math.Between(0, THEME.circleColors.length - 1);
+    const color = THEME.circleColors[colorIndex];
+
+    // 원 생성
+    const circle = this.add.circle(0, 0, radius, color);
+    circle.setStrokeStyle(3, 0xffffff, 0.3);
+
+    // 숫자 텍스트
+    const text = this.add
+      .text(0, 0, requiredTaps.toString(), {
+        fontSize: `${Math.floor(radius * 0.9)}px`,
+        fontFamily: 'Pretendard, sans-serif',
+        color: '#ffffff',
+        fontStyle: 'bold',
+      })
+      .setOrigin(0.5);
+
+    // 컨테이너로 묶기
+    const container = this.add.container(x, y, [circle, text]);
+    container.setDepth(10);
+
+    // 등장 애니메이션
+    container.setScale(0);
+    container.setAlpha(0);
+    this.tweens.add({
+      targets: container,
+      scale: 1,
+      alpha: 1,
+      duration: 200,
+      ease: 'Back.easeOut',
+    });
+
+    // 확장된 터치 영역 (실제 원보다 큰 hitArea)
+    const hitRadius = radius * this.HIT_AREA_MULTIPLIER;
+    const hitArea = new Phaser.Geom.Circle(x, y, hitRadius);
+
+    this.target = {
+      container,
+      circle,
+      text,
+      requiredTaps,
+      currentTaps: 0,
+      hitArea,
+    };
+  }
+
   private updateTimer(): void {
     this.timeLeft--;
     this.timerText.setText(`${this.timeLeft}초`);
+
+    // 10초 이하일 때 빨간색으로
+    if (this.timeLeft <= 10) {
+      this.timerText.setColor('#e94560');
+    }
 
     if (this.timeLeft <= 0) {
       this.endGame();
@@ -109,70 +365,34 @@ export class MainScene extends Phaser.Scene {
   private endGame(): void {
     this.isPlaying = false;
     this.timerEvent?.destroy();
-    this.targetCircle.setVisible(false);
+    this.input.off('pointerdown', this.handleGlobalTouch, this);
 
-    const { width, height } = this.scale;
-
-    // 게임 오버 화면
-    const overlay = this.add.rectangle(width / 2, height / 2, width, height, 0x000000, 0.7);
-
-    this.add
-      .text(width / 2, height / 2 - 60, '게임 종료!', {
-        fontSize: '32px',
-        fontFamily: 'Pretendard, sans-serif',
-        color: '#ffffff',
-      })
-      .setOrigin(0.5);
-
-    this.add
-      .text(width / 2, height / 2, `최종 점수: ${this.score}`, {
-        fontSize: '24px',
-        fontFamily: 'Pretendard, sans-serif',
-        color: '#e94560',
-      })
-      .setOrigin(0.5);
-
-    const restartText = this.add
-      .text(width / 2, height / 2 + 80, '터치하여 다시 시작', {
-        fontSize: '18px',
-        fontFamily: 'Pretendard, sans-serif',
-        color: '#4ecca3',
-      })
-      .setOrigin(0.5);
+    // 타겟 제거
+    if (this.target) {
+      this.target.container.destroy();
+      this.target = null;
+    }
+    this.fadingHitArea = null;
 
     // React에 게임 오버 이벤트 전달
     this.game.events.emit('gameOver', this.score);
 
-    // 다시 시작
-    this.input.once('pointerdown', () => {
-      overlay.destroy();
-      restartText.destroy();
-      this.scene.restart();
+    // 결과 화면으로 전환
+    this.scene.start('ResultScene', {
+      score: this.score,
+      timeUp: this.timeLeft <= 0,
     });
   }
 
-  private moveTarget(): void {
-    const { width, height } = this.scale;
-    const padding = 60;
-
-    const x = Phaser.Math.Between(padding, width - padding);
-    const y = Phaser.Math.Between(100, height - padding);
-
-    this.targetCircle.setPosition(x, y);
-
-    // 크기 랜덤화 (난이도 조절)
-    const scale = Phaser.Math.FloatBetween(0.6, 1.2);
-    this.targetCircle.setScale(scale);
-  }
-
   private handleResize(gameSize: Phaser.Structs.Size): void {
-    const { width, height } = gameSize;
+    const { width } = gameSize;
 
     // UI 위치 조정
     this.timerText?.setPosition(width - 20, 20);
+    this.heartsContainer?.setPosition(width / 2, 25);
   }
 
   update(): void {
-    // 게임 루프 업데이트
+    // 게임 루프 업데이트 (필요 시 사용)
   }
 }

--- a/src/games/brain-touch/scenes/ResultScene.ts
+++ b/src/games/brain-touch/scenes/ResultScene.ts
@@ -1,0 +1,129 @@
+import Phaser from 'phaser';
+import { BASE_COLORS, THEME_PRESETS } from '../../../shared/colors';
+import { createGradientBackground, createButton } from '../../../shared/ui';
+
+const THEME = THEME_PRESETS.brainTouch;
+
+interface ResultData {
+  score: number;
+  timeUp: boolean;
+}
+
+export class ResultScene extends Phaser.Scene {
+  private resultData!: ResultData;
+
+  constructor() {
+    super({ key: 'ResultScene' });
+  }
+
+  init(data: ResultData): void {
+    this.resultData = data;
+  }
+
+  create(): void {
+    const { width, height } = this.scale;
+
+    // 배경
+    createGradientBackground(this, width, height, BASE_COLORS.BG_DARK, BASE_COLORS.BG_PRIMARY);
+
+    // 결과 제목
+    const titleText = this.resultData.timeUp ? '⏱️ 시간 종료!' : '💔 게임 오버';
+    const titleColor = this.resultData.timeUp ? '#4ecca3' : THEME.accentText;
+
+    this.add
+      .text(width / 2, height * 0.25, titleText, {
+        fontSize: '36px',
+        fontFamily: 'Pretendard, sans-serif',
+        color: titleColor,
+        fontStyle: 'bold',
+      })
+      .setOrigin(0.5);
+
+    // 점수 라벨
+    this.add
+      .text(width / 2, height * 0.4, '최종 점수', {
+        fontSize: '18px',
+        fontFamily: 'Pretendard, sans-serif',
+        color: BASE_COLORS.TEXT_SECONDARY,
+      })
+      .setOrigin(0.5);
+
+    // 점수 표시 (애니메이션)
+    const scoreText = this.add
+      .text(width / 2, height * 0.5, '0', {
+        fontSize: '64px',
+        fontFamily: 'Pretendard, sans-serif',
+        color: THEME.accentText,
+        fontStyle: 'bold',
+      })
+      .setOrigin(0.5);
+
+    // 점수 카운트업 애니메이션
+    this.tweens.addCounter({
+      from: 0,
+      to: this.resultData.score,
+      duration: 800,
+      ease: 'Cubic.easeOut',
+      onUpdate: (tween) => {
+        scoreText.setText(Math.floor(tween.getValue()).toString());
+      },
+    });
+
+    // 등급 표시
+    const grade = this.getGrade(this.resultData.score);
+    const gradeText = this.add
+      .text(width / 2, height * 0.62, grade, {
+        fontSize: '28px',
+        fontFamily: 'Pretendard, sans-serif',
+        color: '#ffc947',
+        fontStyle: 'bold',
+      })
+      .setOrigin(0.5)
+      .setAlpha(0);
+
+    // 등급 등장 애니메이션
+    this.time.delayedCall(900, () => {
+      this.tweens.add({
+        targets: gradeText,
+        alpha: 1,
+        scale: { from: 1.5, to: 1 },
+        duration: 300,
+        ease: 'Back.easeOut',
+      });
+    });
+
+    // 버튼들
+    this.time.delayedCall(1200, () => {
+      // 다시하기 버튼
+      createButton(this, width / 2, height * 0.78, '🔄 다시하기', () => {
+        this.scene.start('MainScene');
+      }, {
+        bgColor: THEME.accent,
+        hoverColor: THEME.accentHover,
+        width: 180,
+        height: 50,
+      });
+
+      // 홈으로 버튼
+      createButton(this, width / 2, height * 0.88, '🏠 홈으로', () => {
+        // React 라우터로 홈 이동
+        window.history.back();
+      }, {
+        bgColor: BASE_COLORS.BUTTON_SECONDARY,
+        hoverColor: BASE_COLORS.BUTTON_HOVER,
+        width: 180,
+        height: 50,
+      });
+    });
+  }
+
+  private getGrade(score: number): string {
+    if (score >= 1500) return '🏆 레전드!';
+    if (score >= 1000) return '⭐ 마스터';
+    if (score >= 700) return '🎯 프로';
+    if (score >= 400) return '👍 좋아요';
+    if (score >= 200) return '😊 괜찮아요';
+    return '💪 다시 도전!';
+  }
+}
+

--- a/src/pages/GamePage.tsx
+++ b/src/pages/GamePage.tsx
@@ -10,8 +10,9 @@ export default function GamePage() {
   };
 
   const handleGameOver = () => {
-    // 게임 종료 시 홈으로 이동
-    navigate('/');
+    // 게임 종료 이벤트 수신 (ResultScene에서 이동 처리)
+    // 점수 저장 등 필요한 로직 추가 가능
+    console.log('Game Over event received');
   };
 
   return (

--- a/src/shared/colors.ts
+++ b/src/shared/colors.ts
@@ -29,6 +29,14 @@ export const BASE_COLORS = {
 
 // 게임별 테마 색상 프리셋
 export const THEME_PRESETS = {
+  // Brain Touch - 핑크/레드 계열
+  brainTouch: {
+    accent: 0xe94560,
+    accentHover: 0xf25672,
+    accentText: '#e94560',
+    circleColors: [0xe94560, 0xff6b8a, 0xc73e54, 0xff4757, 0xee5a70],
+  },
+
   // Speed Math - 녹색 계열
   speedMath: {
     accent: 0x4ecca3,


### PR DESCRIPTION
## 📝 변경 사항

Brain Touch 게임을 크게 개선했습니다.

### ✨ 새로운 기능

| 항목 | 이전 | 이후 |
|------|------|------|
| **원 터치** | 1번 터치로 제거 | 숫자만큼 터치해야 제거 |
| **원에 숫자** | 없음 | 1~5 랜덤 숫자 표시 |
| **라이프 시스템** | 없음 | ❤️ 하트 3개 |
| **빈 곳 터치** | 페널티 없음 | 하트 -1 |
| **초과 터치** | N/A | 하트 -1 (숫자보다 더 많이 터치) |
| **터치 범위** | 원 정확히 | 원 크기의 1.4배 (넉넉한 허용) |
| **결과 화면** | 씬 내 오버레이 | ResultScene 분리 (등급 시스템) |
| **점수 체계** | 10점 고정 | 숫자 × 10점 (큰 숫자 보너스) |

### 🎮 게임 규칙

1. 원에 표시된 숫자만큼 터치하면 원이 사라짐
2. 빈 곳 터치 시 하트 감소
3. 숫자보다 더 많이 터치해도 하트 감소
4. 하트가 0이 되거나 30초가 지나면 게임 종료

### 📁 변경된 파일

- `src/games/brain-touch/scenes/MainScene.ts` - 전면 리팩토링
- `src/games/brain-touch/scenes/ResultScene.ts` - 새로 생성
- `src/games/brain-touch/config.ts` - ResultScene 추가
- `src/shared/colors.ts` - brainTouch 테마 추가
- `src/pages/GamePage.tsx` - gameOver 이벤트 처리 수정
- `CLAUDE.md` - 문서 업데이트

### 🐛 버그 수정

- 원이 사라지는 애니메이션 중 추가 터치 시 숫자가 -1이 되는 버그 수정
- gameOver 이벤트가 ResultScene 표시 전에 홈으로 이동하는 버그 수정