### PR TITLE
refactor(shared): TopBar 공통 컴포넌트 구현 및 전체 게임 적용

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,6 +69,7 @@ BrainTouch/
 │   │   ├── colors.ts               # 공통 색상 팔레트 + 테마 프리셋
 │   │   ├── constants.ts            # 공통 상수 (GAME_LAYOUT 등)
 │   │   ├── lives.ts                # 목숨 관리 (LivesManager 클래스)
+│   │   ├── topBar.ts               # 공통 상단 UI 바 (TopBar 클래스)
 │   │   └── ui.ts                   # 공통 UI 유틸리티 (버튼, 배경, 카운트다운, showStartScreen)
 │   └── games/
 │       ├── brain-touch/            # Brain Touch 게임 (숫자 터치)
@@ -172,11 +173,11 @@ BrainTouch/
 - Block Sum 게임 (블록셈 - 다루마 오토시 스타일 덧셈 퍼즐)
 - `DESIGN.md`: 게임 설계 문서
 - `config.ts`: Phaser 게임 설정
-- `scenes/GameScene.ts`: 메인 게임 씬 (블록 탑, 스와이프 제거, 낙하 애니메이션)
+- `scenes/GameScene.ts`: 메인 게임 씬 (블록 탑, 스와이프 제거, 둥근 모서리, 형형색색 블록)
 - `scenes/ResultScene.ts`: 결과 화면
 - `utils/BlockGenerator.ts`: 블록 생성 및 목표 숫자 알고리즘
 - **규칙**: 블록을 스와이프로 제거하여 남은 블록 합 = 목표 숫자
-- **난이도**: 하(4개)→중(5개)→상(6개), 연속 3회 성공 시 승급
+- **난이도**: 하(4개, 1~5, 목표≤15)→중(5개, 1~9, 목표≤25)→상(5개, 1~9, 목표 무제한), 연속 3회 성공 시 승급
 - 상세 내용은 `src/games/block-sum/DESIGN.md` 참조
 
 ### `src/games/number-balloon/`
@@ -194,10 +195,11 @@ BrainTouch/
 ### `src/shared/`
 
 - 게임 간 공통 모듈
-- `colors.ts`: 공통 색상 팔레트 + 게임별 테마 프리셋 (BASE_COLORS, THEME_PRESETS)
+- `colors.ts`: 공통 색상 팔레트 + 게임별 테마 프리셋 (BASE_COLORS, THEME_PRESETS, COLORFUL_PALETTE)
 - `constants.ts`: 공통 상수 (GAME_LAYOUT 등)
 - `ui.ts`: 공통 UI 유틸리티 (버튼, 배경, 카운트다운, 시간 포맷, showStartScreen)
 - `lives.ts`: 목숨 관리 클래스 (LivesManager - 하트 표시, 목숨 증감, 게임오버 체크)
+- `topBar.ts`: 공통 상단 UI 바 (TopBar 클래스 - 점수/시간/하트/진행률/라운드 등 통일된 HUD 제공)
 
 ---
 
@@ -256,6 +258,7 @@ refactor/<game-name>-<description>
 - [x] 공통 모듈 분리 (colors.ts, ui.ts, lives.ts)
 - [x] showStartScreen 공통화 (Brain Touch, Speed Math, Math Flight, Block Sum, Number Balloon)
 - [x] LivesManager 공통화 (Brain Touch, Math Flight)
+- [x] TopBar 공통화 (전체 게임 상단 HUD 통일)
 
 ### 🔲 예정
 
@@ -294,6 +297,9 @@ refactor/<game-name>-<description>
 
 | 날짜       | 작업 내용                                              |
 | ---------- | ------------------------------------------------------ |
+| 2026-01-01 | TopBar 공통 컴포넌트 구현 및 전체 게임 적용 (상단 HUD 통일) |
+| 2026-01-01 | COLORFUL_PALETTE 공통화 (숫자풍선, 블록셈, 브레인터치) |
+| 2026-01-01 | Block Sum 난이도 리밸런스 + 블록 디자인 개선           |
 | 2025-12-28 | 공통 모듈 리팩토링 (showStartScreen, LivesManager 공통화) |
 | 2025-12-28 | Speed Math 모드선택 화면 제거, Home 버튼 수정          |
 | 2025-12-28 | Brain Touch 개선 (숫자 터치, 하트 시스템, ResultScene) |
@@ -316,4 +322,4 @@ refactor/<game-name>-<description>
 
 ---
 
-_마지막 업데이트: 2025-12-28 (리팩토링)_
+_마지막 업데이트: 2026-01-01 (TopBar 공통화)_

--- a/src/games/block-sum/scenes/GameScene.ts
+++ b/src/games/block-sum/scenes/GameScene.ts
@@ -9,8 +9,9 @@ import {
   getDifficultyName,
   getNextDifficulty,
 } from '../utils/BlockGenerator';
-import { BASE_COLORS, THEME_PRESETS } from '../../../shared/colors';
+import { BASE_COLORS, THEME_PRESETS, COLORFUL_PALETTE } from '../../../shared/colors';
 import { createGradientBackground, showStartScreen } from '../../../shared/ui';
+import { TopBar, TOP_BAR } from '../../../shared/topBar';
 
 // 게임 색상
 const COLORS = {
@@ -18,9 +19,11 @@ const COLORS = {
   ACCENT: THEME_PRESETS.blockSum.accent,
   ACCENT_HOVER: THEME_PRESETS.blockSum.accentHover,
   ACCENT_TEXT: THEME_PRESETS.blockSum.accentText,
-  BLOCK_BG: 0x2a2a4e,
-  BLOCK_SELECTED: 0x4a4a6e,
+  BLOCK_SELECTED: 0x6a6a8e,
 };
+
+// 블록 색상 팔레트 (공통 팔레트 사용)
+const BLOCK_COLORS = COLORFUL_PALETTE;
 
 // 블록 스프라이트 정보
 interface BlockSprite {
@@ -43,8 +46,7 @@ export class GameScene extends Phaser.Scene {
   private blockSprites: BlockSprite[] = [];
 
   // UI 요소
-  private timerText!: Phaser.GameObjects.Text;
-  private scoreText!: Phaser.GameObjects.Text;
+  private topBar!: TopBar;
   private difficultyText!: Phaser.GameObjects.Text;
   private targetText!: Phaser.GameObjects.Text;
   private blockContainer!: Phaser.GameObjects.Container;
@@ -113,8 +115,9 @@ export class GameScene extends Phaser.Scene {
   }
 
   private calculateLayout(width: number, height: number): void {
-    this.blockWidth = Math.min(width * 0.7, 280);
-    this.blockHeight = Math.min(height * 0.08, 60);
+    // 블록 가로를 3/4로 줄이고, 높이는 1.5배로
+    this.blockWidth = Math.min(width * 0.525, 210); // 기존 0.7 * 0.75 = 0.525
+    this.blockHeight = Math.min(height * 0.12, 90); // 기존 0.08 * 1.5 = 0.12
   }
 
   private setupGlobalSwipeDetection(): void {
@@ -147,42 +150,43 @@ export class GameScene extends Phaser.Scene {
     this.input.on('pointerup', () => {
       if (!this.selectedBlock) return;
 
-      // 스와이프 취소 - 원래 색으로
-      const bg = this.selectedBlock.container.getAt(0) as Phaser.GameObjects.Rectangle;
-      bg?.setFillStyle(COLORS.BLOCK_BG);
+      // 스와이프 취소 - 원래 색으로 복원
+      const container = this.selectedBlock.container as any;
+      const bg = container.bgGraphics as Phaser.GameObjects.Graphics;
+      const originalColor = container.originalColor;
+      if (bg && originalColor !== undefined) {
+        const radius = 16;
+        bg.clear();
+        bg.fillStyle(originalColor, 1);
+        bg.fillRoundedRect(
+          -this.blockWidth / 2,
+          -this.blockHeight / 2,
+          this.blockWidth,
+          this.blockHeight,
+          radius
+        );
+      }
 
       this.selectedBlock = null;
     });
   }
 
   private createHUD(width: number): void {
-    // 타이머 (좌상단)
-    this.timerText = this.add
-      .text(20, 20, '60.0', {
-        fontSize: '28px',
-        fontFamily: 'Pretendard, sans-serif',
-        color: COLORS.ACCENT_TEXT,
-        fontStyle: 'bold',
-      })
-      .setOrigin(0, 0);
+    // 공통 상단 바 생성
+    this.topBar = new TopBar(this, {
+      left: { type: 'time', initialValue: 60, color: COLORS.ACCENT_TEXT },
+      right: { type: 'score', initialValue: 0 },
+    });
 
-    // 점수 (우상단)
-    this.scoreText = this.add
-      .text(width - 20, 20, '0점', {
-        fontSize: '24px',
-        fontFamily: 'Pretendard, sans-serif',
-        color: COLORS.TEXT_PRIMARY,
-      })
-      .setOrigin(1, 0);
-
-    // 난이도 (우상단 아래)
+    // 난이도 (우상단 아래, TopBar 바깥)
     this.difficultyText = this.add
-      .text(width - 20, 50, '난이도: 하', {
-        fontSize: '16px',
+      .text(width - TOP_BAR.PADDING_X, TOP_BAR.HEIGHT + 5, '난이도: 하', {
+        fontSize: '14px',
         fontFamily: 'Pretendard, sans-serif',
         color: COLORS.TEXT_SECONDARY,
       })
-      .setOrigin(1, 0);
+      .setOrigin(1, 0)
+      .setDepth(100);
   }
 
   private createTargetArea(width: number, height: number): void {
@@ -230,35 +234,55 @@ export class GameScene extends Phaser.Scene {
 
     blocks.forEach((blockData, index) => {
       const y = startY + index * (this.blockHeight + this.blockGap);
-      const blockSprite = this.createBlockSprite(blockData, 0, y);
+      const blockSprite = this.createBlockSprite(blockData, 0, y, index);
       this.blockSprites.push(blockSprite);
       this.blockContainer.add(blockSprite.container);
     });
   }
 
-  private createBlockSprite(data: BlockData, x: number, y: number): BlockSprite {
+  private createBlockSprite(
+    data: BlockData,
+    x: number,
+    y: number,
+    colorIndex: number
+  ): BlockSprite {
     const container = this.add.container(x, y);
 
-    // 블록 배경
-    const bg = this.add
-      .rectangle(0, 0, this.blockWidth, this.blockHeight, COLORS.BLOCK_BG, 1)
-      .setStrokeStyle(2, 0x4a4a6e);
+    // 블록 색상 선택
+    const blockColor = BLOCK_COLORS[colorIndex % BLOCK_COLORS.length];
+    const radius = 16; // 모서리 둥글기
 
-    // 숫자
+    // 둥근 모서리 블록 배경 (Graphics 사용)
+    const bg = this.add.graphics();
+    bg.fillStyle(blockColor, 1);
+    bg.fillRoundedRect(
+      -this.blockWidth / 2,
+      -this.blockHeight / 2,
+      this.blockWidth,
+      this.blockHeight,
+      radius
+    );
+
+    // 인터랙션용 히트 영역 (투명 사각형)
+    const hitArea = this.add
+      .rectangle(0, 0, this.blockWidth, this.blockHeight, 0x000000, 0)
+      .setInteractive({ useHandCursor: true, draggable: false });
+
+    // 숫자 (폰트 사이즈 증가)
     const text = this.add
       .text(0, 0, String(data.value), {
-        fontSize: '32px',
+        fontSize: '44px',
         fontFamily: 'Pretendard, sans-serif',
-        color: COLORS.TEXT_PRIMARY,
+        color: '#ffffff',
         fontStyle: 'bold',
       })
       .setOrigin(0.5);
 
-    container.add([bg, text]);
-    container.setSize(this.blockWidth, this.blockHeight);
+    // 텍스트에 그림자 효과 추가
+    text.setShadow(2, 2, 'rgba(0,0,0,0.3)', 4);
 
-    // 인터랙션 설정
-    bg.setInteractive({ useHandCursor: true, draggable: false });
+    container.add([bg, hitArea, text]);
+    container.setSize(this.blockWidth, this.blockHeight);
 
     const blockSprite: BlockSprite = {
       data,
@@ -267,21 +291,28 @@ export class GameScene extends Phaser.Scene {
     };
 
     // pointerdown에서 블록 선택 및 스와이프 시작점 기록
-    bg.on('pointerdown', (pointer: Phaser.Input.Pointer) => {
+    hitArea.on('pointerdown', (pointer: Phaser.Input.Pointer) => {
       if (!this.isPlaying || blockSprite.isRemoving) return;
       this.selectedBlock = blockSprite;
       this.swipeStartX = pointer.x;
       this.swipeStartY = pointer.y;
       this.swipeStartTime = pointer.time;
 
-      // 선택 효과
-      bg.setFillStyle(COLORS.BLOCK_SELECTED);
+      // 선택 효과 (밝게)
+      bg.clear();
+      bg.fillStyle(COLORS.BLOCK_SELECTED, 1);
+      bg.fillRoundedRect(
+        -this.blockWidth / 2,
+        -this.blockHeight / 2,
+        this.blockWidth,
+        this.blockHeight,
+        radius
+      );
     });
 
-    // pointerout에서는 색상만 변경, selectedBlock은 유지 (전역 pointerup에서 처리)
-    bg.on('pointerout', () => {
-      // 드래그 중에는 색상 유지
-    });
+    // 선택 해제 시 원래 색상 복원을 위해 blockColor 저장
+    (container as any).originalColor = blockColor;
+    (container as any).bgGraphics = bg;
 
     return blockSprite;
   }
@@ -341,7 +372,7 @@ export class GameScene extends Phaser.Scene {
     const roundScore = baseScore * bonusMultiplier * difficultyBonus;
 
     this.score += roundScore;
-    this.scoreText.setText(`${this.score}점`);
+    this.topBar.updateValue('right', this.score);
 
     // 성공 효과
     this.showSuccessFeedback(roundScore);
@@ -475,11 +506,11 @@ export class GameScene extends Phaser.Scene {
     this.timeLeft -= 100;
 
     const seconds = Math.max(0, this.timeLeft / 1000);
-    this.timerText.setText(seconds.toFixed(1));
+    this.topBar.updateValue('left', parseFloat(seconds.toFixed(1)));
 
     // 10초 이하일 때 빨간색
     if (this.timeLeft <= 10000) {
-      this.timerText.setColor('#e94560');
+      this.topBar.setColor('left', '#e94560');
     }
 
     // 타임오버
@@ -499,9 +530,13 @@ export class GameScene extends Phaser.Scene {
   }
 
   private handleResize(gameSize: Phaser.Structs.Size): void {
-    // 필요 시 리사이즈 로직 추가
     const { width, height } = gameSize;
     this.calculateLayout(width, height);
+
+    // 상단 바 리사이즈 대응
+    this.topBar?.handleResize(width);
+
+    // 난이도 텍스트 위치 조정
+    this.difficultyText?.setPosition(width - TOP_BAR.PADDING_X, TOP_BAR.HEIGHT + 5);
   }
 }
-

--- a/src/games/brain-touch/scenes/MainScene.ts
+++ b/src/games/brain-touch/scenes/MainScene.ts
@@ -1,7 +1,7 @@
 import Phaser from 'phaser';
-import { THEME_PRESETS } from '../../../shared/colors';
+import { THEME_PRESETS, COLORFUL_PALETTE } from '../../../shared/colors';
 import { createGradientBackground, showStartScreen } from '../../../shared/ui';
-import { LivesManager } from '../../../shared/lives';
+import { TopBar, TOP_BAR } from '../../../shared/topBar';
 
 const THEME = THEME_PRESETS.brainTouch;
 
@@ -28,9 +28,7 @@ export class MainScene extends Phaser.Scene {
   private readonly HIT_AREA_MULTIPLIER = 1.4; // 터치 허용 범위 확장
 
   // UI 요소
-  private scoreText!: Phaser.GameObjects.Text;
-  private timerText!: Phaser.GameObjects.Text;
-  private livesManager!: LivesManager;
+  private topBar!: TopBar;
 
   constructor() {
     super({ key: 'MainScene' });
@@ -53,34 +51,11 @@ export class MainScene extends Phaser.Scene {
   }
 
   private createUI(): void {
-    const { width } = this.scale;
-
-    // 점수 텍스트
-    this.scoreText = this.add
-      .text(20, 20, '점수: 0', {
-        fontSize: '22px',
-        fontFamily: 'Pretendard, sans-serif',
-        color: THEME.accentText,
-        fontStyle: 'bold',
-      })
-      .setDepth(100);
-
-    // 타이머 텍스트
-    this.timerText = this.add
-      .text(width - 20, 20, `${this.timeLeft}초`, {
-        fontSize: '22px',
-        fontFamily: 'Pretendard, sans-serif',
-        color: '#4ecca3',
-        fontStyle: 'bold',
-      })
-      .setOrigin(1, 0)
-      .setDepth(100);
-
-    // 하트(라이프) 매니저
-    this.livesManager = new LivesManager(this, {
-      x: width / 2,
-      y: 25,
-      maxLives: 3,
+    // 공통 상단 바 생성
+    this.topBar = new TopBar(this, {
+      left: { type: 'score', initialValue: 0, color: THEME.accentText },
+      center: { type: 'lives', maxLives: 3 },
+      right: { type: 'time', initialValue: this.timeLeft, color: '#4ecca3' },
     });
   }
 
@@ -97,8 +72,8 @@ export class MainScene extends Phaser.Scene {
     this.score = 0;
     this.timeLeft = 30;
 
-    this.scoreText.setText('점수: 0');
-    this.livesManager.reset();
+    this.topBar.updateValue('left', 0);
+    this.topBar.resetLives('center');
 
     // 첫 번째 타겟 생성
     this.spawnTarget();
@@ -156,7 +131,7 @@ export class MainScene extends Phaser.Scene {
       // 원 완료 - 점수 획득
       const bonusMultiplier = this.target.requiredTaps; // 큰 숫자일수록 보너스
       this.score += 10 * bonusMultiplier;
-      this.scoreText.setText(`점수: ${this.score}`);
+      this.topBar.updateValue('left', this.score);
 
       // 사라지는 원의 hitArea 저장 (빈 곳 터치 판정용)
       this.fadingHitArea = this.target.hitArea;
@@ -195,7 +170,7 @@ export class MainScene extends Phaser.Scene {
   }
 
   private loseLife(): void {
-    const isGameOver = this.livesManager.loseLife();
+    const isGameOver = this.topBar.loseLife('center');
 
     // 화면 흔들림 효과
     this.cameras.main.shake(100, 0.01);
@@ -235,9 +210,9 @@ export class MainScene extends Phaser.Scene {
     const scale = 0.8 + requiredTaps * 0.1;
     const radius = this.BASE_RADIUS * scale;
 
-    // 랜덤 색상
-    const colorIndex = Phaser.Math.Between(0, THEME.circleColors.length - 1);
-    const color = THEME.circleColors[colorIndex];
+    // 랜덤 색상 (공통 팔레트 사용)
+    const colorIndex = Phaser.Math.Between(0, COLORFUL_PALETTE.length - 1);
+    const color = COLORFUL_PALETTE[colorIndex];
 
     // 원 생성
     const circle = this.add.circle(0, 0, radius, color);
@@ -284,11 +259,11 @@ export class MainScene extends Phaser.Scene {
 
   private updateTimer(): void {
     this.timeLeft--;
-    this.timerText.setText(`${this.timeLeft}초`);
+    this.topBar.updateValue('right', this.timeLeft);
 
     // 10초 이하일 때 빨간색으로
     if (this.timeLeft <= 10) {
-      this.timerText.setColor('#e94560');
+      this.topBar.setColor('right', '#e94560');
     }
 
     if (this.timeLeft <= 0) {
@@ -318,9 +293,8 @@ export class MainScene extends Phaser.Scene {
   private handleResize(gameSize: Phaser.Structs.Size): void {
     const { width } = gameSize;
 
-    // UI 위치 조정
-    this.timerText?.setPosition(width - 20, 20);
-    this.livesManager?.setPosition(width / 2, 25);
+    // 상단 바 리사이즈 대응
+    this.topBar?.handleResize(width);
   }
 
   update(): void {

--- a/src/games/math-flight/scenes/GameScene.ts
+++ b/src/games/math-flight/scenes/GameScene.ts
@@ -10,7 +10,7 @@ import {
 } from '../utils/MeteorGenerator';
 import { BASE_COLORS, THEME_PRESETS } from '../../../shared/colors';
 import { showStartScreen } from '../../../shared/ui';
-import { LivesManager } from '../../../shared/lives';
+import { TopBar, TOP_BAR } from '../../../shared/topBar';
 
 const THEME = THEME_PRESETS.mathFlight;
 
@@ -40,8 +40,7 @@ export class GameScene extends Phaser.Scene {
   private isPointerDown = false; // 드래그 상태 추적
 
   // UI 요소
-  private livesManager!: LivesManager;
-  private scoreText!: Phaser.GameObjects.Text;
+  private topBar!: TopBar;
   private player!: Phaser.GameObjects.Container;
 
   // 운석
@@ -76,7 +75,7 @@ export class GameScene extends Phaser.Scene {
     this.createLaneLines(width, height);
 
     // HUD
-    this.createHUD(width);
+    this.createHUD();
 
     // 플레이어
     this.createPlayer();
@@ -145,23 +144,11 @@ export class GameScene extends Phaser.Scene {
     }
   }
 
-  private createHUD(width: number): void {
-    // 점수 (좌상단)
-    this.scoreText = this.add
-      .text(16, 16, '0점', {
-        fontSize: '24px',
-        fontFamily: 'Pretendard, sans-serif',
-        color: BASE_COLORS.TEXT_PRIMARY,
-        fontStyle: 'bold',
-      })
-      .setOrigin(0, 0);
-
-    // 라이프 (우상단)
-    this.livesManager = new LivesManager(this, {
-      x: width - 60,
-      y: 16,
-      maxLives: 3,
-      align: 'right',
+  private createHUD(): void {
+    // 공통 상단 바 생성
+    this.topBar = new TopBar(this, {
+      left: { type: 'score', initialValue: 0 },
+      right: { type: 'lives', maxLives: 3 },
     });
   }
 
@@ -376,7 +363,7 @@ export class GameScene extends Phaser.Scene {
       this.showSuccessEffect(meteor, earnedScore, isMedianMeteor(type));
     } else {
       // 실패 (min 또는 max)
-      const isGameOver = this.livesManager.loseLife();
+      const isGameOver = this.topBar.loseLife('right');
       this.showFailEffect();
 
       if (isGameOver) {
@@ -385,7 +372,7 @@ export class GameScene extends Phaser.Scene {
       }
     }
 
-    this.scoreText.setText(`${this.score}점`);
+    this.topBar.updateValue('left', this.score);
   }
 
   private showSuccessEffect(meteor: MeteorSprite, score: number, isMedian: boolean): void {
@@ -450,7 +437,7 @@ export class GameScene extends Phaser.Scene {
   }
 
   private updateScoreDisplay(): void {
-    this.scoreText.setText(`${this.score}점`);
+    this.topBar.updateValue('left', this.score);
   }
 
   private checkNextWave(): void {
@@ -486,7 +473,7 @@ export class GameScene extends Phaser.Scene {
     const { width, height } = gameSize;
     this.calculateLayout(width, height);
 
-    this.livesManager?.setPosition(width - 60, 16);
+    this.topBar?.handleResize(width);
 
     if (this.player) {
       this.playerX = Phaser.Math.Clamp(this.playerX, 30, width - 30);

--- a/src/games/number-balloon/scenes/GameScene.ts
+++ b/src/games/number-balloon/scenes/GameScene.ts
@@ -6,6 +6,8 @@ import {
   getRoundConfig,
 } from '../utils/BalloonGenerator';
 import { showStartScreen } from '../../../shared/ui';
+import { TopBar, TOP_BAR } from '../../../shared/topBar';
+import { BASE_COLORS } from '../../../shared/colors';
 
 // 게임 색상
 const COLORS = {
@@ -38,7 +40,6 @@ interface BalloonBody {
 export class GameScene extends Phaser.Scene {
   // 게임 상태
   private score = 0;
-  private lives = 3;
   private round = 1;
   private totalPopped = 0;
   private isPlaying = false;
@@ -50,9 +51,7 @@ export class GameScene extends Phaser.Scene {
   private currentIndex = 0;
 
   // UI 요소
-  private livesText!: Phaser.GameObjects.Text;
-  private scoreText!: Phaser.GameObjects.Text;
-  private roundText!: Phaser.GameObjects.Text;
+  private topBar!: TopBar;
   private instructionText!: Phaser.GameObjects.Text;
   private difficultyText!: Phaser.GameObjects.Text;
 
@@ -70,7 +69,6 @@ export class GameScene extends Phaser.Scene {
 
     // 상태 초기화
     this.score = 0;
-    this.lives = 3;
     this.round = 1;
     this.totalPopped = 0;
     this.isPlaying = false;
@@ -127,9 +125,10 @@ export class GameScene extends Phaser.Scene {
   }
 
   private calculateLayout(width: number, height: number): void {
-    const hudHeight = 80;
-    const instructionHeight = 50;
-    this.gameAreaTop = hudHeight + instructionHeight;
+    const hudHeight = TOP_BAR.HEIGHT;
+    const difficultyHeight = 25; // 난이도 텍스트 영역
+    const instructionHeight = 40;
+    this.gameAreaTop = hudHeight + difficultyHeight + instructionHeight;
     this.gameAreaWidth = width;
     this.gameAreaHeight = height - this.gameAreaTop - 20;
   }
@@ -184,49 +183,26 @@ export class GameScene extends Phaser.Scene {
   }
 
   private createHUD(width: number): void {
-    const hudY = 25;
+    // 공통 상단 바 생성 (배경 포함)
+    this.topBar = new TopBar(this, {
+      left: { type: 'lives', maxLives: 3 },
+      center: { type: 'round', initialValue: 1 },
+      right: { type: 'score', initialValue: 0, color: '#ffc947' },
+      showBackground: true,
+      backgroundColor: COLORS.HUD_BG,
+      backgroundAlpha: 0.9,
+    });
 
-    // HUD 배경
-    const hudBg = this.add.rectangle(width / 2, 40, width, 80, COLORS.HUD_BG, 0.9);
-    hudBg.setOrigin(0.5);
-
-    // 라이프 (왼쪽)
-    this.livesText = this.add
-      .text(20, hudY, '❤️❤️❤️', {
-        fontSize: '24px',
-        fontFamily: 'Pretendard, sans-serif',
-      })
-      .setOrigin(0, 0.5);
-
-    // 라운드 (중앙)
-    this.roundText = this.add
-      .text(width / 2, hudY, 'Round 1', {
-        fontSize: '20px',
-        fontFamily: 'Pretendard, sans-serif',
-        color: COLORS.TEXT_PRIMARY,
-        fontStyle: 'bold',
-      })
-      .setOrigin(0.5);
-
-    // 점수 (오른쪽)
-    this.scoreText = this.add
-      .text(width - 20, hudY, '0점', {
-        fontSize: '24px',
-        fontFamily: 'Pretendard, sans-serif',
-        color: '#ffc947',
-        fontStyle: 'bold',
-      })
-      .setOrigin(1, 0.5);
-
-    // 난이도 표시
+    // 난이도 표시 (TopBar 바깥)
     const config = getRoundConfig(this.round);
     this.difficultyText = this.add
-      .text(width / 2, hudY + 25, `풍선 ${config.balloonCount}개`, {
+      .text(width / 2, TOP_BAR.HEIGHT + 10, `풍선 ${config.balloonCount}개`, {
         fontSize: '14px',
         fontFamily: 'Pretendard, sans-serif',
         color: COLORS.TEXT_SECONDARY,
       })
-      .setOrigin(0.5);
+      .setOrigin(0.5)
+      .setDepth(100);
   }
 
   private prepareRound(): void {
@@ -247,7 +223,7 @@ export class GameScene extends Phaser.Scene {
     this.createBalloonBodies();
 
     // UI 업데이트
-    this.roundText.setText(`Round ${this.round}`);
+    this.topBar.updateValue('center', this.round);
     const config = getRoundConfig(this.round);
     this.difficultyText.setText(`풍선 ${config.balloonCount}개`);
   }
@@ -350,7 +326,7 @@ export class GameScene extends Phaser.Scene {
     // 점수 추가
     const points = 10 * this.round;
     this.score += points;
-    this.scoreText.setText(`${this.score}점`);
+    this.topBar.updateValue('right', this.score);
 
     // 터지는 애니메이션
     this.popBalloon(balloon, true);
@@ -362,14 +338,14 @@ export class GameScene extends Phaser.Scene {
   }
 
   private handleWrongTap(balloon: BalloonBody): void {
-    this.lives--;
-    this.updateLivesDisplay();
+    // TopBar의 LivesManager를 통해 목숨 감소
+    const isGameOver = this.topBar.loseLife('left');
 
     // 틀린 피드백
     this.showWrongFeedback(balloon);
 
     // 게임 오버 체크
-    if (this.lives <= 0) {
+    if (isGameOver) {
       this.endGame();
     }
   }
@@ -462,10 +438,6 @@ export class GameScene extends Phaser.Scene {
     });
   }
 
-  private updateLivesDisplay(): void {
-    const hearts = '❤️'.repeat(this.lives) + '🖤'.repeat(3 - this.lives);
-    this.livesText.setText(hearts);
-  }
 
   private handleRoundClear(): void {
     this.round++;
@@ -515,5 +487,11 @@ export class GameScene extends Phaser.Scene {
     const { width, height } = gameSize;
     this.calculateLayout(width, height);
     this.setupWorldBounds(width, height);
+
+    // 상단 바 리사이즈 대응
+    this.topBar?.handleResize(width);
+
+    // 난이도 텍스트 위치 조정
+    this.difficultyText?.setPosition(width / 2, TOP_BAR.HEIGHT + 10);
   }
 }

--- a/src/games/speed-math/scenes/GameScene.ts
+++ b/src/games/speed-math/scenes/GameScene.ts
@@ -1,6 +1,8 @@
 import Phaser from 'phaser';
 import { Question, generateQuestions, isSingleDigitAnswer } from '../utils/QuestionGenerator';
 import { showStartScreen } from '../../../shared/ui';
+import { TopBar, TOP_BAR } from '../../../shared/topBar';
+import { BASE_COLORS } from '../../../shared/colors';
 
 // 색상 상수
 const COLORS = {
@@ -26,8 +28,7 @@ export class GameScene extends Phaser.Scene {
   private isPlaying = false;
 
   // UI 요소
-  private timerText!: Phaser.GameObjects.Text;
-  private progressText!: Phaser.GameObjects.Text;
+  private topBar!: TopBar;
 
   // 문제 표시 (3개)
   private questionContainer!: Phaser.GameObjects.Container;
@@ -58,7 +59,7 @@ export class GameScene extends Phaser.Scene {
     this.createBackground(width, height);
 
     // HUD (진행률, 타이머)
-    this.createHUD(width);
+    this.createHUD();
 
     // 문제 영역 (3개 문제 표시)
     this.createQuestionArea(width, height);
@@ -72,8 +73,7 @@ export class GameScene extends Phaser.Scene {
     // 처음에는 게임 영역 숨김
     this.questionContainer.setAlpha(0);
     this.padContainer.setAlpha(0);
-    this.progressText.setAlpha(0);
-    this.timerText.setAlpha(0);
+    this.topBar.setAlpha(0);
 
     // 시작 화면 표시
     showStartScreen(this, {
@@ -92,10 +92,11 @@ export class GameScene extends Phaser.Scene {
   private showGameUI(): void {
     // 게임 UI 페이드인
     this.tweens.add({
-      targets: [this.questionContainer, this.padContainer, this.progressText, this.timerText],
+      targets: [this.questionContainer, this.padContainer, this.topBar.getContainer()],
       alpha: 1,
       duration: 200,
     });
+    this.topBar.setAlpha(1);
   }
 
   private createBackground(width: number, height: number): void {
@@ -109,24 +110,12 @@ export class GameScene extends Phaser.Scene {
     bg.fillRect(0, 0, width, height);
   }
 
-  private createHUD(width: number): void {
-    // 진행률 (좌상단)
-    this.progressText = this.add
-      .text(16, 16, '1/20', {
-        fontSize: '20px',
-        fontFamily: 'Pretendard, sans-serif',
-        color: COLORS.TEXT_PRIMARY,
-      })
-      .setOrigin(0, 0);
-
-    // 타이머 (우상단, 작게)
-    this.timerText = this.add
-      .text(width - 16, 16, '0.00초', {
-        fontSize: '16px',
-        fontFamily: 'Pretendard, sans-serif',
-        color: COLORS.TEXT_SECONDARY,
-      })
-      .setOrigin(1, 0);
+  private createHUD(): void {
+    // 공통 상단 바 생성
+    this.topBar = new TopBar(this, {
+      left: { type: 'progress', initialValue: '1/20' },
+      right: { type: 'text', initialValue: '0.00초', color: BASE_COLORS.TEXT_SECONDARY },
+    });
   }
 
   private createQuestionArea(width: number, height: number): void {
@@ -331,7 +320,7 @@ export class GameScene extends Phaser.Scene {
     }
 
     // 진행률 업데이트
-    this.progressText.setText(`${this.currentQuestionIndex + 1}/${this.TOTAL_QUESTIONS}`);
+    this.topBar.updateValue('left', `${this.currentQuestionIndex + 1}/${this.TOTAL_QUESTIONS}`);
   }
 
   private checkAnswer(): void {
@@ -482,14 +471,14 @@ export class GameScene extends Phaser.Scene {
     if (this.isPlaying) {
       const elapsed = Date.now() - this.startTime;
       const seconds = (elapsed / 1000).toFixed(2);
-      this.timerText.setText(`${seconds}초`);
+      this.topBar.updateValue('right', `${seconds}초`);
     }
   }
 
   private handleResize(gameSize: Phaser.Structs.Size): void {
     const { width } = gameSize;
 
-    // HUD 위치 조정
-    this.timerText?.setPosition(width - 16, 16);
+    // 상단 바 리사이즈 대응
+    this.topBar?.handleResize(width);
   }
 }

--- a/src/shared/lives.ts
+++ b/src/shared/lives.ts
@@ -125,6 +125,13 @@ export class LivesManager {
   }
 
   /**
+   * 알파값 설정 (페이드인/아웃용)
+   */
+  setAlpha(alpha: number): void {
+    this.container.setAlpha(alpha);
+  }
+
+  /**
    * 정리 (씬 전환 시)
    */
   destroy(): void {

--- a/src/shared/topBar.ts
+++ b/src/shared/topBar.ts
@@ -1,0 +1,368 @@
+/**
+ * 브레인터치 공통 상단 UI 바
+ * 모든 게임에서 통일된 상단 HUD를 제공
+ */
+
+import Phaser from 'phaser';
+import { BASE_COLORS } from './colors';
+import { LivesManager } from './lives';
+
+// 상단 바 레이아웃 상수
+export const TOP_BAR = {
+  HEIGHT: 50, // 상단 바 높이
+  PADDING_X: 16, // 좌우 패딩
+  CENTER_Y: 25, // 중앙 Y 좌표 (HEIGHT / 2)
+  FONT_SIZE: {
+    MAIN: '22px', // 주요 요소 (점수, 시간 등)
+    SUB: '14px', // 부가 요소 (라벨 등)
+  },
+  FONT_FAMILY: 'Pretendard, sans-serif',
+} as const;
+
+// 슬롯 위치
+export type SlotPosition = 'left' | 'center' | 'right';
+
+// 슬롯에 배치할 수 있는 요소 타입
+export type SlotItemType = 'lives' | 'score' | 'time' | 'progress' | 'round' | 'text';
+
+// 슬롯 아이템 설정
+export interface SlotItemConfig {
+  type: SlotItemType;
+  label?: string; // 라벨 (예: "점수", "시간")
+  showLabel?: boolean; // 라벨 표시 여부
+  color?: string; // 텍스트 색상
+  initialValue?: string | number; // 초기 값
+  maxLives?: number; // lives 타입일 때 최대 목숨 수
+}
+
+// TopBar 설정
+export interface TopBarConfig {
+  left?: SlotItemConfig;
+  center?: SlotItemConfig;
+  right?: SlotItemConfig;
+  showBackground?: boolean; // 배경 표시 여부
+  backgroundColor?: number; // 배경 색상
+  backgroundAlpha?: number; // 배경 투명도
+}
+
+// 슬롯 아이템 컨테이너
+interface SlotItem {
+  container: Phaser.GameObjects.Container;
+  valueText?: Phaser.GameObjects.Text;
+  labelText?: Phaser.GameObjects.Text;
+  livesManager?: LivesManager;
+  config: SlotItemConfig;
+}
+
+/**
+ * TopBar 클래스
+ * 게임 상단에 통일된 HUD를 제공
+ */
+export class TopBar {
+  private scene: Phaser.Scene;
+  private container: Phaser.GameObjects.Container;
+  private background?: Phaser.GameObjects.Rectangle;
+  private items: Map<SlotPosition, SlotItem> = new Map();
+  private width: number;
+
+  constructor(scene: Phaser.Scene, config: TopBarConfig) {
+    this.scene = scene;
+    this.width = scene.scale.width;
+
+    // 컨테이너 생성
+    this.container = scene.add.container(0, 0);
+    this.container.setDepth(100); // 항상 상단에 표시
+
+    // 배경 (선택적)
+    if (config.showBackground) {
+      this.background = scene.add.rectangle(
+        this.width / 2,
+        TOP_BAR.HEIGHT / 2,
+        this.width,
+        TOP_BAR.HEIGHT,
+        config.backgroundColor ?? BASE_COLORS.HUD_BG,
+        config.backgroundAlpha ?? 0.9
+      );
+      this.container.add(this.background);
+    }
+
+    // 각 슬롯 생성
+    if (config.left) {
+      this.createSlotItem('left', config.left);
+    }
+    if (config.center) {
+      this.createSlotItem('center', config.center);
+    }
+    if (config.right) {
+      this.createSlotItem('right', config.right);
+    }
+  }
+
+  private createSlotItem(position: SlotPosition, config: SlotItemConfig): void {
+    const slotContainer = this.scene.add.container(0, 0);
+
+    // X 좌표 계산
+    const x = this.getSlotX(position);
+
+    // 원점 설정 (left: 왼쪽 정렬, center: 중앙 정렬, right: 오른쪽 정렬)
+    const originX = position === 'left' ? 0 : position === 'right' ? 1 : 0.5;
+
+    const item: SlotItem = {
+      container: slotContainer,
+      config,
+    };
+
+    if (config.type === 'lives') {
+      // 하트(라이프) 표시
+      const livesManager = new LivesManager(this.scene, {
+        x,
+        y: TOP_BAR.CENTER_Y,
+        maxLives: config.maxLives ?? 3,
+        align: position === 'right' ? 'right' : position === 'center' ? 'center' : 'left',
+      });
+      item.livesManager = livesManager;
+      // LivesManager는 자체적으로 씬에 추가되므로 container에 추가하지 않음
+    } else {
+      // 텍스트 기반 요소
+      const color = config.color ?? BASE_COLORS.TEXT_PRIMARY;
+      const initialValue = this.formatValue(config.type, config.initialValue);
+
+      // 값 텍스트
+      const valueText = this.scene.add
+        .text(x, TOP_BAR.CENTER_Y, initialValue, {
+          fontSize: TOP_BAR.FONT_SIZE.MAIN,
+          fontFamily: TOP_BAR.FONT_FAMILY,
+          color,
+          fontStyle: 'bold',
+        })
+        .setOrigin(originX, 0.5);
+
+      item.valueText = valueText;
+      slotContainer.add(valueText);
+
+      // 라벨 (선택적)
+      if (config.showLabel && config.label) {
+        const labelX = position === 'left' ? x : position === 'right' ? x : x;
+        const labelY = TOP_BAR.CENTER_Y + 18;
+
+        const labelText = this.scene.add
+          .text(labelX, labelY, config.label, {
+            fontSize: TOP_BAR.FONT_SIZE.SUB,
+            fontFamily: TOP_BAR.FONT_FAMILY,
+            color: BASE_COLORS.TEXT_SECONDARY,
+          })
+          .setOrigin(originX, 0.5);
+
+        item.labelText = labelText;
+        slotContainer.add(labelText);
+      }
+    }
+
+    this.container.add(slotContainer);
+    this.items.set(position, item);
+  }
+
+  private getSlotX(position: SlotPosition): number {
+    switch (position) {
+      case 'left':
+        return TOP_BAR.PADDING_X;
+      case 'center':
+        return this.width / 2;
+      case 'right':
+        return this.width - TOP_BAR.PADDING_X;
+    }
+  }
+
+  private formatValue(type: SlotItemType, value?: string | number): string {
+    if (value === undefined || value === null) {
+      switch (type) {
+        case 'score':
+          return '0점';
+        case 'time':
+          return '0초';
+        case 'progress':
+          return '0/0';
+        case 'round':
+          return 'Round 1';
+        default:
+          return '';
+      }
+    }
+
+    switch (type) {
+      case 'score':
+        return `${value}점`;
+      case 'time':
+        if (typeof value === 'number') {
+          // 소수점 여부에 따라 포맷팅
+          return Number.isInteger(value) ? `${value}초` : `${value.toFixed(1)}초`;
+        }
+        return `${value}`;
+      case 'progress':
+        return String(value);
+      case 'round':
+        return typeof value === 'number' ? `Round ${value}` : String(value);
+      default:
+        return String(value);
+    }
+  }
+
+  /**
+   * 슬롯 값 업데이트
+   */
+  public updateValue(position: SlotPosition, value: string | number): void {
+    const item = this.items.get(position);
+    if (!item || !item.valueText) return;
+
+    const formattedValue = this.formatValue(item.config.type, value);
+    item.valueText.setText(formattedValue);
+  }
+
+  /**
+   * 슬롯 색상 업데이트
+   */
+  public setColor(position: SlotPosition, color: string): void {
+    const item = this.items.get(position);
+    if (!item || !item.valueText) return;
+
+    item.valueText.setColor(color);
+  }
+
+  /**
+   * LivesManager 반환 (lives 타입 슬롯)
+   */
+  public getLivesManager(position: SlotPosition): LivesManager | undefined {
+    const item = this.items.get(position);
+    return item?.livesManager;
+  }
+
+  /**
+   * 목숨 감소 (lives 타입 슬롯)
+   * @returns true면 게임오버
+   */
+  public loseLife(position: SlotPosition = 'left'): boolean {
+    const livesManager = this.getLivesManager(position);
+    if (!livesManager) {
+      // lives가 없는 슬롯에서 호출 시 right 슬롯도 확인
+      const rightLives = this.getLivesManager('right');
+      if (rightLives) {
+        return rightLives.loseLife();
+      }
+      return false;
+    }
+    return livesManager.loseLife();
+  }
+
+  /**
+   * 목숨 리셋 (lives 타입 슬롯)
+   */
+  public resetLives(position: SlotPosition = 'left'): void {
+    const livesManager = this.getLivesManager(position);
+    livesManager?.reset();
+  }
+
+  /**
+   * 화면 리사이즈 대응
+   */
+  public handleResize(width: number): void {
+    this.width = width;
+
+    // 배경 크기 조정
+    if (this.background) {
+      this.background.setPosition(width / 2, TOP_BAR.HEIGHT / 2);
+      this.background.setSize(width, TOP_BAR.HEIGHT);
+    }
+
+    // 각 슬롯 위치 업데이트
+    this.items.forEach((item, position) => {
+      const x = this.getSlotX(position);
+      const originX = position === 'left' ? 0 : position === 'right' ? 1 : 0.5;
+
+      if (item.valueText) {
+        item.valueText.setPosition(x, TOP_BAR.CENTER_Y);
+        item.valueText.setOrigin(originX, 0.5);
+      }
+
+      if (item.labelText) {
+        item.labelText.setPosition(x, TOP_BAR.CENTER_Y + 18);
+        item.labelText.setOrigin(originX, 0.5);
+      }
+
+      if (item.livesManager) {
+        item.livesManager.setPosition(x, TOP_BAR.CENTER_Y);
+      }
+    });
+  }
+
+  /**
+   * 알파값 설정 (페이드인/아웃용)
+   */
+  public setAlpha(alpha: number): void {
+    this.container.setAlpha(alpha);
+    // LivesManager는 별도로 처리
+    this.items.forEach((item) => {
+      if (item.livesManager) {
+        item.livesManager.setAlpha(alpha);
+      }
+    });
+  }
+
+  /**
+   * 컨테이너 반환 (tween 등에 사용)
+   */
+  public getContainer(): Phaser.GameObjects.Container {
+    return this.container;
+  }
+
+  /**
+   * 정리
+   */
+  public destroy(): void {
+    this.items.forEach((item) => {
+      item.container.destroy();
+      item.livesManager?.destroy();
+    });
+    this.container.destroy();
+  }
+}
+
+/**
+ * 게임별 TopBar 프리셋
+ */
+export const TOP_BAR_PRESETS = {
+  // Brain Touch: 점수 | 하트 | 시간
+  brainTouch: {
+    left: { type: 'score' as const, initialValue: 0 },
+    center: { type: 'lives' as const, maxLives: 3 },
+    right: { type: 'time' as const, initialValue: 30, color: '#4ecca3' },
+  },
+
+  // Speed Math: 진행률 | - | 시간
+  speedMath: {
+    left: { type: 'progress' as const, initialValue: '1/20' },
+    right: { type: 'time' as const, initialValue: '0.00', color: BASE_COLORS.TEXT_SECONDARY },
+  },
+
+  // Math Flight: 점수 | - | 하트
+  mathFlight: {
+    left: { type: 'score' as const, initialValue: 0 },
+    right: { type: 'lives' as const, maxLives: 3 },
+  },
+
+  // Block Sum: 시간 | - | 점수 (+ 난이도 아래)
+  blockSum: {
+    left: { type: 'time' as const, initialValue: 60, color: '#ffc947' },
+    right: { type: 'score' as const, initialValue: 0 },
+  },
+
+  // Number Balloon: 하트 | 라운드 | 점수
+  numberBalloon: {
+    left: { type: 'lives' as const, maxLives: 3 },
+    center: { type: 'round' as const, initialValue: 1 },
+    right: { type: 'score' as const, initialValue: 0, color: '#ffc947' },
+    showBackground: true,
+    backgroundColor: BASE_COLORS.HUD_BG,
+    backgroundAlpha: 0.9,
+  },
+} as const;
+


### PR DESCRIPTION
## 📋 변경 사항

### 🎯 목적
모바일(특히 아이폰 SE 같은 작은 화면)에서 각 게임의 상단 UI가 정렬/크기가 제각각이던 문제를 해결하기 위해 **공통 TopBar 컴포넌트**를 구현하고 전체 게임에 적용했습니다.

### ✨ 주요 변경

#### 1. 새 파일 추가
- `src/shared/topBar.ts`: 공통 상단 UI 바 컴포넌트

#### 2. TopBar 설계 원칙
| 항목 | 값 |
|------|-----|
| 높이 | 50px (고정) |
| 좌우 패딩 | 16px |
| 폰트 크기 | 22px (메인), 14px (서브) |
| 레이아웃 | 3분할 (왼쪽 / 중앙 / 오른쪽) |

#### 3. 각 게임별 TopBar 구성
| 게임 | 왼쪽 | 중앙 | 오른쪽 |
|------|------|------|--------|
| Brain Touch | 점수 | 하트 | 시간 |
| Speed Math | 진행률 | - | 시간 |
| Math Flight | 점수 | - | 하트 |
| Block Sum | 시간 | - | 점수 |
| Number Balloon | 하트 | 라운드 | 점수 |

#### 4. 지원하는 슬롯 타입
- `lives`: 하트 (LivesManager 통합)
- `score`: 점수 (자동 "점" 접미사)
- `time`: 시간 (자동 "초" 접미사)
- `progress`: 진행률 (예: "1/20")
- `round`: 라운드 (예: "Round 1")
- `text`: 자유 텍스트

### 📝 기타 변경
- `LivesManager`에 `setAlpha()` 메서드 추가
- `CLAUDE.md` 문서 업데이트

### 🧪 테스트
- [x] Brain Touch 상단 UI 확인
- [x] Speed Math 상단 UI 확인
- [x] Math Flight 상단 UI 확인
- [x] Block Sum 상단 UI 확인
- [x] Number Balloon 상단 UI 확인
- [x] 아이폰 SE 크기 화면에서 정렬 확인