### PR TITLE
fix: clean up scene resize listeners on shutdown

### DIFF
--- a/src/games/block-sum/scenes/GameScene.ts
+++ b/src/games/block-sum/scenes/GameScene.ts
@@ -141,6 +141,7 @@ export class GameScene extends Phaser.Scene {
     });
 
     this.scale.on('resize', this.handleResize, this);
+    this.events.once(Phaser.Scenes.Events.SHUTDOWN, this.cleanupResizeListener, this);
   }
 
   private calculateLayout(width: number, height: number): void {
@@ -647,5 +648,9 @@ export class GameScene extends Phaser.Scene {
     this.calculateLayout(width, gameSize.height);
     this.topBar?.handleResize(width);
     this.handleTimerBarResize(width);
+  }
+
+  private cleanupResizeListener(): void {
+    this.scale.off('resize', this.handleResize, this);
   }
 }

--- a/src/games/brain-touch/scenes/MainScene.ts
+++ b/src/games/brain-touch/scenes/MainScene.ts
@@ -49,6 +49,7 @@ export class MainScene extends Phaser.Scene {
 
     // 리사이즈 대응
     this.scale.on('resize', this.handleResize, this);
+    this.events.once(Phaser.Scenes.Events.SHUTDOWN, this.cleanupResizeListener, this);
   }
 
   private createUI(): void {
@@ -300,6 +301,10 @@ export class MainScene extends Phaser.Scene {
 
     // 상단 바 리사이즈 대응
     this.topBar?.handleResize(width);
+  }
+
+  private cleanupResizeListener(): void {
+    this.scale.off('resize', this.handleResize, this);
   }
 
   update(): void {

--- a/src/games/math-flight/scenes/GameScene.ts
+++ b/src/games/math-flight/scenes/GameScene.ts
@@ -160,6 +160,7 @@ export class GameScene extends Phaser.Scene {
 
     // 리사이즈 대응
     this.scale.on('resize', this.handleResize, this);
+    this.events.once(Phaser.Scenes.Events.SHUTDOWN, this.cleanupResizeListener, this);
   }
 
   private getTextResolution(): number {
@@ -631,5 +632,9 @@ export class GameScene extends Phaser.Scene {
       this.player.y = this.playerY;
       this.playerBody?.setDisplaySize(this.playerSize, this.playerSize);
     }
+  }
+
+  private cleanupResizeListener(): void {
+    this.scale.off('resize', this.handleResize, this);
   }
 }

--- a/src/games/number-balloon/scenes/GameScene.ts
+++ b/src/games/number-balloon/scenes/GameScene.ts
@@ -129,6 +129,7 @@ export class GameScene extends Phaser.Scene {
     });
 
     this.scale.on('resize', this.handleResize, this);
+    this.events.once(Phaser.Scenes.Events.SHUTDOWN, this.cleanupResizeListener, this);
   }
 
   update(): void {
@@ -624,5 +625,8 @@ export class GameScene extends Phaser.Scene {
     this.topBar?.handleResize(width);
     this.handleTimerBarResize(width);
   }
-}
 
+  private cleanupResizeListener(): void {
+    this.scale.off('resize', this.handleResize, this);
+  }
+}

--- a/src/games/speed-math/scenes/GameScene.ts
+++ b/src/games/speed-math/scenes/GameScene.ts
@@ -87,6 +87,7 @@ export class GameScene extends Phaser.Scene {
 
     // 리사이즈 대응
     this.scale.on('resize', this.handleResize, this);
+    this.events.once(Phaser.Scenes.Events.SHUTDOWN, this.cleanupResizeListener, this);
   }
 
   private showGameUI(): void {
@@ -483,5 +484,9 @@ export class GameScene extends Phaser.Scene {
 
     // 상단 바 리사이즈 대응
     this.topBar?.handleResize(width);
+  }
+
+  private cleanupResizeListener(): void {
+    this.scale.off('resize', this.handleResize, this);
   }
 }


### PR DESCRIPTION
## What changed
- add `shutdown` cleanup for scene-level `resize` listeners in Brain Touch, Speed Math, Math Flight, Block Sum, and Number Balloon
- keep the fix scoped to listener lifecycle so repeated scene re-entry does not accumulate duplicate resize handlers

## Validation
- `npm install`
- `npm run build`

## Related issue
- closes #25

## Route
- chosen route: `direct-impl`
- judge artifact: `.codex-workflows/github-issue-impl-pr-loop/issue-25/judge-route.json`

## Docs
- no doc update needed; this change only fixes runtime listener cleanup and does not alter user-facing flow or terminology