### PR TITLE
fix: prevent repeated wrong-tap life drain in Number Balloon

### DIFF
--- a/src/games/number-balloon/scenes/GameScene.ts
+++ b/src/games/number-balloon/scenes/GameScene.ts
@@ -398,7 +398,7 @@ export class GameScene extends Phaser.Scene {
     }
 
     this.time.delayedCall(500, () => {
-      if (this.isPlaying) {
+      if (this.isPlaying && this.roundTimeLeft > 0 && this.roundTimerEvent) {
         this.isInputLocked = false;
       }
     });


### PR DESCRIPTION
## Summary
- add a round-level input lock while wrong-tap feedback is active
- ignore repeated taps during the lock so one wrong feedback only consumes one life
- reset the lock when a new round starts and keep input blocked during timeout/game-over transitions

## Validation
- `npm run build`

## Related Issue
- closes #44

## Route
- chosen route: `direct-impl`
- judge artifact: `.codex-workflows/github-issue-impl-pr-loop/issue-44/judge-route.json`

## Docs
- no doc update needed: gameplay rule itself did not change, only wrong-input handling was stabilized