### PR TITLE
fix: guard PhaserGame async mount lifecycle (#59)

### DIFF
--- a/src/components/PhaserGame.tsx
+++ b/src/components/PhaserGame.tsx
@@ -13,20 +13,35 @@ export default function PhaserGame({ gameId, onGameOver }: PhaserGameProps) {
 
   useEffect(() => {
     if (!containerRef.current || gameRef.current) return;
+    let disposed = false;
 
     // 폰트 로딩 완료 후 게임 시작
     const loadGame = async () => {
       try {
         // 폰트 로딩 대기 (Cherry Bomb One 등)
         await waitForFonts();
+        if (disposed) return;
 
         // 게임별 설정 동적 import
         const gameModule = await import(`../games/${gameId}/config.ts`);
-        const config = gameModule.getGameConfig(containerRef.current!, onGameOver);
-        
-        gameRef.current = new Phaser.Game(config);
+        if (disposed) return;
+
+        const container = containerRef.current;
+        if (!container) return;
+
+        const config = gameModule.getGameConfig(container, onGameOver);
+        const game = new Phaser.Game(config);
+
+        if (disposed) {
+          game.destroy(true);
+          return;
+        }
+
+        gameRef.current = game;
       } catch (error) {
-        console.error(`Failed to load game: ${gameId}`, error);
+        if (!disposed) {
+          console.error(`Failed to load game: ${gameId}`, error);
+        }
       }
     };
 
@@ -34,6 +49,7 @@ export default function PhaserGame({ gameId, onGameOver }: PhaserGameProps) {
 
     // Cleanup
     return () => {
+      disposed = true;
       if (gameRef.current) {
         gameRef.current.destroy(true);
         gameRef.current = null;
@@ -64,4 +80,3 @@ export default function PhaserGame({ gameId, onGameOver }: PhaserGameProps) {
     />
   );
 }
-


### PR DESCRIPTION
## What changed
- added a local disposal guard inside `PhaserGame` async loading effect
- stop config creation and `new Phaser.Game(...)` when the component unmounted during font loading or dynamic import
- destroy the just-created game immediately if unmount wins the race after config creation

## Validation
- `npm install`
- `npm run build`

## Route
- chosen route: `direct-impl`
- judge artifact: `.codex-workflows/github-issue-impl-pr/issue-59-phasergame-unmount-race/judge-route.json`

## Docs
- no doc update needed
- reason: runtime lifecycle guard only, no user-visible flow or spec change

## Related issue
- closes #59