### PR TITLE
refactor(app): split game route bundle for faster home load

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,7 +1,19 @@
+import { Suspense, lazy } from 'react';
 import { Link, Navigate, Route, Routes, useParams } from 'react-router-dom';
 import HomePage from './pages/HomePage';
-import GamePage from './pages/GamePage';
 import { getGameCatalogItem } from './shared/gameCatalog';
+
+const GamePage = lazy(() => import('./pages/GamePage'));
+
+function RouteLoadingFallback() {
+  return (
+    <div className="w-full h-full flex items-center justify-center bg-toss-black px-6 text-white">
+      <div className="rounded-2xl border border-toss-gray-600 bg-toss-gray-700/80 px-5 py-4 text-sm text-toss-gray-200">
+        게임 화면을 불러오는 중입니다...
+      </div>
+    </div>
+  );
+}
 
 function LegacyShareInvalidPage() {
   return (
@@ -36,11 +48,13 @@ function LegacyShareRedirect() {
 function App() {
   return (
     <div className="w-full h-full">
-      <Routes>
-        <Route path="/" element={<HomePage />} />
-        <Route path="/game/:gameId" element={<GamePage />} />
-        <Route path="/share/:gameId" element={<LegacyShareRedirect />} />
-      </Routes>
+      <Suspense fallback={<RouteLoadingFallback />}>
+        <Routes>
+          <Route path="/" element={<HomePage />} />
+          <Route path="/game/:gameId" element={<GamePage />} />
+          <Route path="/share/:gameId" element={<LegacyShareRedirect />} />
+        </Routes>
+      </Suspense>
     </div>
   );
 }


### PR DESCRIPTION
## 요약
- `App`에서 `GamePage`를 `React.lazy`로 지연 로드해 홈 진입 번들에서 Phaser 경로를 분리했습니다.
- 게임 라우트가 로드되는 동안 보여 줄 `Suspense` fallback을 추가했습니다.
- `#38`의 JS 번들 원인으로 좁혀진 `App -> GamePage -> PhaserGame` 정적 import 체인을 끊는 데 집중했습니다.

## 검증
- `npm run build`
- 변경 전: `dist/assets/index-BHsNzYYs.js` 1,651.92 kB (gzip 382.40 kB)
- 변경 후: `dist/assets/index-C0YV6d8p.js` 168.61 kB (gzip 55.37 kB)
- 변경 후 분리 청크: `dist/assets/GamePage-0utPBCtw.js` 1,484.03 kB (gzip 327.42 kB)
- 참고: `math-flight` PNG 대형 에셋과 게임 청크 경고는 여전히 남아 있어 `#38`의 다음 최적화 여지는 유지됩니다.

## 관련 이슈
- Closes #38

## Route
- chosen route: `direct-impl`
- judge artifact: `.codex-workflows/github-issue-impl-pr/issue-38/judge-route.json`

## 문서 동기화 메모
- no doc update needed: 사용자 동작은 유지한 채 라우트 로딩 방식만 조정한 변경입니다.