### PR TITLE
fix(shared): relayout active game scenes on resize

### DIFF
--- a/src/games/block-sum/scenes/GameScene.ts
+++ b/src/games/block-sum/scenes/GameScene.ts
@@ -48,6 +48,8 @@ interface BlockSprite {
   data: BlockData;
   container: Phaser.GameObjects.Container;
   bgGraphics: Phaser.GameObjects.Graphics;
+  hitArea: Phaser.GameObjects.Rectangle;
+  valueText: Phaser.GameObjects.Text;
   originalColor: number;
   isRemoving: boolean;
 }
@@ -76,6 +78,7 @@ export class GameScene extends Phaser.Scene {
   private telemetryEntries: RoundTelemetryEntry[] = [];
 
   private topBar!: TopBar;
+  private background?: Phaser.GameObjects.Graphics;
   private targetLabel!: Phaser.GameObjects.Text;
   private targetText!: Phaser.GameObjects.Text;
   private blockContainer!: Phaser.GameObjects.Container;
@@ -122,7 +125,7 @@ export class GameScene extends Phaser.Scene {
     this.telemetryEntries = [];
 
     this.calculateLayout(width, height);
-    createGradientBackground(this, width, height);
+    this.background = createGradientBackground(this, width, height).setDepth(-1);
 
     this.createHUD();
     this.createTargetArea(width, height);
@@ -348,6 +351,8 @@ export class GameScene extends Phaser.Scene {
       data,
       container,
       bgGraphics: bg,
+      hitArea,
+      valueText: text,
       originalColor: blockColor,
       isRemoving: false,
     };
@@ -643,11 +648,56 @@ export class GameScene extends Phaser.Scene {
     });
   }
 
+  private redrawBackground(width: number, height: number): void {
+    this.background?.destroy();
+    this.background = createGradientBackground(this, width, height).setDepth(-1);
+  }
+
+  private updateTargetAreaLayout(width: number, height: number): void {
+    const targetY = height * 0.15;
+    this.targetLabel?.setPosition(width / 2, targetY - 25);
+    this.targetText?.setPosition(width / 2, targetY + 15);
+    this.blockContainer?.setPosition(width / 2, height * 0.5);
+  }
+
+  private refreshActiveBlockLayout(): void {
+    const activeBlocks = this.blockSprites.filter((blockSprite) => !blockSprite.isRemoving);
+    const totalHeight = activeBlocks.length * (this.blockHeight + this.blockGap) - this.blockGap;
+    const startY = -totalHeight / 2 + this.blockHeight / 2;
+    const radius = 16;
+
+    activeBlocks.forEach((blockSprite, index) => {
+      const y = startY + index * (this.blockHeight + this.blockGap);
+      const fillColor =
+        this.selectedBlock === blockSprite ? COLORS.BLOCK_SELECTED : blockSprite.originalColor;
+
+      blockSprite.container.setPosition(0, y);
+      blockSprite.container.setSize(this.blockWidth, this.blockHeight);
+
+      blockSprite.bgGraphics.clear();
+      blockSprite.bgGraphics.fillStyle(fillColor, 1);
+      blockSprite.bgGraphics.fillRoundedRect(
+        -this.blockWidth / 2,
+        -this.blockHeight / 2,
+        this.blockWidth,
+        this.blockHeight,
+        radius
+      );
+
+      blockSprite.hitArea.setSize(this.blockWidth, this.blockHeight);
+      blockSprite.valueText.setFontSize(`${Math.max(Math.round(this.blockHeight * 0.5), 32)}px`);
+      blockSprite.valueText.setPosition(0, 0);
+    });
+  }
+
   private handleResize(gameSize: Phaser.Structs.Size): void {
-    const { width } = gameSize;
+    const { width, height } = gameSize;
     this.calculateLayout(width, gameSize.height);
+    this.redrawBackground(width, height);
     this.topBar?.handleResize(width);
     this.handleTimerBarResize(width);
+    this.updateTargetAreaLayout(width, height);
+    this.refreshActiveBlockLayout();
   }
 
   private cleanupResizeListener(): void {

--- a/src/games/brain-touch/scenes/MainScene.ts
+++ b/src/games/brain-touch/scenes/MainScene.ts
@@ -30,6 +30,9 @@ export class MainScene extends Phaser.Scene {
 
   // UI 요소
   private topBar!: TopBar;
+  private background?: Phaser.GameObjects.Graphics;
+  private sceneWidth = 0;
+  private sceneHeight = 0;
 
   constructor() {
     super({ key: 'MainScene' });
@@ -37,9 +40,11 @@ export class MainScene extends Phaser.Scene {
 
   create(): void {
     const { width, height } = this.scale;
+    this.sceneWidth = width;
+    this.sceneHeight = height;
 
     // 배경
-    createGradientBackground(this, width, height);
+    this.background = createGradientBackground(this, width, height).setDepth(-1);
 
     // UI 초기화
     this.createUI();
@@ -300,11 +305,55 @@ export class MainScene extends Phaser.Scene {
     this.scale.off('resize', this.handleResize, this);
   }
 
+  private redrawBackground(width: number, height: number): void {
+    this.background?.destroy();
+    this.background = createGradientBackground(this, width, height).setDepth(-1);
+  }
+
   private handleResize(gameSize: Phaser.Structs.Size): void {
-    const { width } = gameSize;
+    const { width, height } = gameSize;
+    const previousWidth = this.sceneWidth;
+    const previousHeight = this.sceneHeight;
+
+    this.sceneWidth = width;
+    this.sceneHeight = height;
+    this.redrawBackground(width, height);
 
     // 상단 바 리사이즈 대응
     this.topBar?.handleResize(width);
+
+    const minTargetY = TOP_BAR.HEIGHT + 60;
+    const updatePoint = (x: number, y: number, radius: number) => {
+      const nextX = Phaser.Math.Clamp((x / Math.max(previousWidth, 1)) * width, radius + 24, width - radius - 24);
+      const nextY = Phaser.Math.Clamp(
+        (y / Math.max(previousHeight, 1)) * height,
+        minTargetY,
+        height - radius - 24,
+      );
+
+      return { x: nextX, y: nextY };
+    };
+
+    if (this.target) {
+      const { x, y } = updatePoint(
+        this.target.container.x,
+        this.target.container.y,
+        this.target.hitArea.radius,
+      );
+      this.target.container.setPosition(x, y);
+      this.target.hitArea.x = x;
+      this.target.hitArea.y = y;
+    }
+
+    if (this.fadingHitArea) {
+      const { x, y } = updatePoint(
+        this.fadingHitArea.x,
+        this.fadingHitArea.y,
+        this.fadingHitArea.radius,
+      );
+      this.fadingHitArea.x = x;
+      this.fadingHitArea.y = y;
+    }
   }
 
   update(): void {

--- a/src/games/number-balloon/scenes/GameScene.ts
+++ b/src/games/number-balloon/scenes/GameScene.ts
@@ -75,6 +75,8 @@ export class GameScene extends Phaser.Scene {
   private currentIndex = 0;
 
   private topBar!: TopBar;
+  private background?: Phaser.GameObjects.Graphics;
+  private clouds: Phaser.GameObjects.Graphics[] = [];
   private instructionText!: Phaser.GameObjects.Text;
   private timerBarBg!: Phaser.GameObjects.Rectangle;
   private timerBarFill!: Phaser.GameObjects.Rectangle;
@@ -84,6 +86,8 @@ export class GameScene extends Phaser.Scene {
   private gameAreaWidth = 0;
   private gameAreaHeight = 0;
   private gameAreaTop = 0;
+  private sceneWidth = 0;
+  private sceneHeight = 0;
 
   constructor() {
     super({ key: 'GameScene' });
@@ -91,6 +95,8 @@ export class GameScene extends Phaser.Scene {
 
   create(): void {
     const { width, height } = this.scale;
+    this.sceneWidth = width;
+    this.sceneHeight = height;
 
     this.score = 0;
     this.round = 1;
@@ -173,9 +179,13 @@ export class GameScene extends Phaser.Scene {
   }
 
   private createBackground(width: number, height: number): void {
-    const bg = this.add.graphics();
-    bg.fillGradientStyle(0x87ceeb, 0x87ceeb, 0xb0e0e6, 0xb0e0e6);
-    bg.fillRect(0, 0, width, height);
+    this.background?.destroy();
+    this.clouds.forEach((cloud) => cloud.destroy());
+    this.clouds = [];
+
+    this.background = this.add.graphics().setDepth(-2);
+    this.background.fillGradientStyle(0x87ceeb, 0x87ceeb, 0xb0e0e6, 0xb0e0e6);
+    this.background.fillRect(0, 0, width, height);
 
     this.addClouds(width);
   }
@@ -194,6 +204,8 @@ export class GameScene extends Phaser.Scene {
       cloud.fillCircle(25 * pos.scale, -5, 25 * pos.scale);
       cloud.fillCircle(50 * pos.scale, 0, 20 * pos.scale);
       cloud.setPosition(pos.x, pos.y);
+      cloud.setDepth(-1);
+      this.clouds.push(cloud);
     });
   }
 
@@ -634,12 +646,45 @@ export class GameScene extends Phaser.Scene {
     this.scale.off('resize', this.handleResize, this);
   }
 
+  private relayoutBalloonBodies(previousWidth: number, previousHeight: number): void {
+    this.balloonBodies.forEach((balloon) => {
+      if (balloon.isPopped) {
+        return;
+      }
+
+      const nextX = Phaser.Math.Clamp(
+        (balloon.body.position.x / Math.max(previousWidth, 1)) * this.gameAreaWidth,
+        balloon.data.size,
+        this.gameAreaWidth - balloon.data.size,
+      );
+      const nextY = Phaser.Math.Clamp(
+        (balloon.body.position.y / Math.max(previousHeight, 1)) * this.gameAreaHeight,
+        balloon.data.size,
+        this.gameAreaHeight - balloon.data.size,
+      );
+
+      balloon.data.x = nextX;
+      balloon.data.y = nextY;
+      this.matter.body.setPosition(balloon.body, { x: nextX, y: nextY });
+      balloon.graphics.setPosition(nextX, nextY + this.gameAreaTop);
+      balloon.text.setPosition(nextX, nextY + this.gameAreaTop);
+    });
+  }
+
   private handleResize(gameSize: Phaser.Structs.Size): void {
     const { width, height } = gameSize;
+    const previousGameAreaWidth = this.gameAreaWidth;
+    const previousGameAreaHeight = this.gameAreaHeight;
+
+    this.sceneWidth = width;
+    this.sceneHeight = height;
     this.calculateLayout(width, height);
+    this.createBackground(width, height);
     this.setupWorldBounds(width, height);
 
     this.topBar?.handleResize(width);
     this.handleTimerBarResize(width);
+    this.instructionText?.setPosition(width / 2, this.gameAreaTop - 30);
+    this.relayoutBalloonBodies(previousGameAreaWidth, previousGameAreaHeight);
   }
 }

--- a/src/games/speed-math/scenes/GameScene.ts
+++ b/src/games/speed-math/scenes/GameScene.ts
@@ -30,6 +30,7 @@ export class GameScene extends Phaser.Scene {
 
   // UI 요소
   private topBar!: TopBar;
+  private background?: Phaser.GameObjects.Graphics;
 
   // 문제 표시 (3개)
   private questionContainer!: Phaser.GameObjects.Container;
@@ -103,14 +104,14 @@ export class GameScene extends Phaser.Scene {
   }
 
   private createBackground(width: number, height: number): void {
-    const bg = this.add.graphics();
-    bg.fillGradientStyle(
+    this.background = this.add.graphics().setDepth(-1);
+    this.background.fillGradientStyle(
       COLORS.BG_PRIMARY,
       COLORS.BG_PRIMARY,
       COLORS.BG_SECONDARY,
       COLORS.BG_SECONDARY
     );
-    bg.fillRect(0, 0, width, height);
+    this.background.fillRect(0, 0, width, height);
   }
 
   private createHUD(): void {
@@ -484,7 +485,22 @@ export class GameScene extends Phaser.Scene {
   }
 
   private handleResize(gameSize: Phaser.Structs.Size): void {
-    const { width } = gameSize;
+    const { width, height } = gameSize;
+    const questionAlpha = this.questionContainer?.alpha ?? 0;
+    const padAlpha = this.padContainer?.alpha ?? 0;
+
+    this.background?.destroy();
+    this.questionContainer?.destroy();
+    this.padContainer?.destroy();
+
+    this.createBackground(width, height);
+    this.createQuestionArea(width, height);
+    this.createNumberPad(width, height);
+
+    this.questionContainer.setAlpha(questionAlpha);
+    this.padContainer.setAlpha(padAlpha);
+    this.updateQuestionDisplay();
+    this.updateAnswerDisplay();
 
     // 상단 바 리사이즈 대응
     this.topBar?.handleResize(width);


### PR DESCRIPTION
## 요약
- brain-touch에서 활성 타겟과 hit area를 resize 비율에 맞춰 재배치하도록 수정했습니다.
- speed-math에서 resize 시 문제 영역과 숫자패드를 현재 진행 상태 기준으로 재구성하도록 수정했습니다.
- block-sum과 number-balloon에서 활성 라운드 레이아웃을 새 viewport에 맞춰 다시 계산하도록 수정했습니다.

## 검증
- `npm run build`

## 관련 이슈
- Closes #48

## 구현 경로
- chosen route: `direct-impl`
- judge artifact: `.codex-workflows/github-issue-impl-pr/issue-48/judge-route.json`
- document sync note: no doc update needed; runtime resize handling 수정만 포함했습니다.
